### PR TITLE
Update colabs to be tf2 compatible

### DIFF
--- a/WIT_Age_Regression.ipynb
+++ b/WIT_Age_Regression.ipynb
@@ -4,7 +4,6 @@
   "metadata": {
     "colab": {
       "name": "WIT Age Regression",
-      "version": "0.3.2",
       "provenance": [],
       "collapsed_sections": []
     },
@@ -15,11 +14,11 @@
   },
   "cells": [
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "UiNxsd4_q9wq",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "### What-If Tool - age-predicting regression model\n",
         "\n",
@@ -34,12 +33,12 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "qqB2tjOMETmr",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Install the What-If Tool widget if running in colab {display-mode: \"form\"}\n",
         "\n",
@@ -53,12 +52,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "jlwjF-Nnmoww",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Define helper functions {display-mode: \"form\"}\n",
         "\n",
@@ -74,11 +73,11 @@
         "        columns = df.columns.values.tolist()\n",
         "    for f in columns:\n",
         "        if df[f].dtype is np.dtype(np.int64) or df[f].dtype is np.dtype(np.int32):\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.int64)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.int64)\n",
         "        elif df[f].dtype is np.dtype(np.float64):\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.float32)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.float32)\n",
         "        else:\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.string)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.string)\n",
         "    return feature_spec\n",
         "\n",
         "# Creates simple numeric and categorical feature columns from a feature spec and a\n",
@@ -114,7 +113,7 @@
         "\n",
         "# Parses Tf.Example protos into features for the input function.\n",
         "def parse_tf_example(example_proto, label, feature_spec):\n",
-        "    parsed_features = tf.parse_example(serialized=example_proto, features=feature_spec)\n",
+        "    parsed_features = tf.io.parse_example(serialized=example_proto, features=feature_spec)\n",
         "    target = parsed_features.pop(label)\n",
         "    return parsed_features, target\n",
         "\n",
@@ -144,12 +143,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "nu398ARdeuxe",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Read training dataset from CSV {display-mode: \"form\"}\n",
         "\n",
@@ -174,12 +173,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "67DYIFxoevt2",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Specify input columns and column to predict {display-mode: \"form\"}\n",
         "import numpy as np\n",
@@ -200,12 +199,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "BV4f_4_Lex22",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Convert dataset to tf.Example protos {display-mode: \"form\"}\n",
         "\n",
@@ -215,17 +214,16 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "YyLr-_0de1Ii",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Create and train the regressor {display-mode: \"form\"}\n",
         "\n",
-        "num_steps = 2000  #@param {type: \"number\"}\n",
-        "tf.logging.set_verbosity(tf.logging.DEBUG)\n",
+        "num_steps = 200  #@param {type: \"number\"}\n",
         "\n",
         "# Create a feature spec for the classifier\n",
         "feature_spec = create_feature_spec(df, features_and_labels)\n",
@@ -240,12 +238,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "NUQVro76e38Q",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Invoke What-If Tool for test data and the trained model {display-mode: \"form\"}\n",
         "\n",
@@ -270,11 +268,11 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "7VlncgiQTDFw",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "#### Exploration ideas\n",
         "\n",

--- a/WIT_COMPAS.ipynb
+++ b/WIT_COMPAS.ipynb
@@ -4,7 +4,6 @@
   "metadata": {
     "colab": {
       "name": "WIT COMPAS",
-      "version": "0.3.2",
       "provenance": [],
       "collapsed_sections": []
     },
@@ -15,11 +14,11 @@
   },
   "cells": [
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "UiNxsd4_q9wq",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "### What-If Tool on COMPAS\n",
         "\n",
@@ -42,12 +41,12 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "qqB2tjOMETmr",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Install the What-If Tool widget if running in colab {display-mode: \"form\"}\n",
         "\n",
@@ -61,12 +60,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "jlwjF-Nnmoww",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Define helper functions {display-mode: \"form\"}\n",
         "\n",
@@ -82,11 +81,11 @@
         "        columns = df.columns.values.tolist()\n",
         "    for f in columns:\n",
         "        if df[f].dtype is np.dtype(np.int64):\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.int64)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.int64)\n",
         "        elif df[f].dtype is np.dtype(np.float64):\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.float32)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.float32)\n",
         "        else:\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.string)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.string)\n",
         "    return feature_spec\n",
         "\n",
         "# Creates simple numeric and categorical feature columns from a feature spec and a\n",
@@ -122,7 +121,7 @@
         "\n",
         "# Parses Tf.Example protos into features for the input function.\n",
         "def parse_tf_example(example_proto, label, feature_spec):\n",
-        "    parsed_features = tf.parse_example(serialized=example_proto, features=feature_spec)\n",
+        "    parsed_features = tf.io.parse_example(serialized=example_proto, features=feature_spec)\n",
         "    target = parsed_features.pop(label)\n",
         "    return parsed_features, target\n",
         "\n",
@@ -152,12 +151,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "nu398ARdeuxe",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Read training dataset from CSV {display-mode: \"form\"}\n",
         "\n",
@@ -170,12 +169,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "67DYIFxoevt2",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Specify input columns and column to predict {display-mode: \"form\"}\n",
         "import numpy as np\n",
@@ -203,12 +202,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "BV4f_4_Lex22",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Convert dataset to tf.Example protos {display-mode: \"form\"}\n",
         "\n",
@@ -218,17 +217,16 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "YyLr-_0de1Ii",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Create and train the classifier {display-mode: \"form\"}\n",
         "\n",
         "num_steps = 2000  #@param {type: \"number\"}\n",
-        "tf.logging.set_verbosity(tf.logging.DEBUG)\n",
         "\n",
         "# Create a feature spec for the classifier\n",
         "feature_spec = create_feature_spec(df, features_and_labels)\n",
@@ -243,11 +241,11 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "VZ-rK11X5arK",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "### What-If Tool analysis\n",
         "\n",
@@ -262,12 +260,12 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "NUQVro76e38Q",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Invoke What-If Tool for test data and the trained models {display-mode: \"form\"}\n",
         "\n",
@@ -287,11 +285,11 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "bOVamCz1LsTd",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "#### Exploration ideas\n",
         "\n",

--- a/WIT_Model_Comparison.ipynb
+++ b/WIT_Model_Comparison.ipynb
@@ -4,7 +4,6 @@
   "metadata": {
     "colab": {
       "name": "WIT Model Comparison",
-      "version": "0.3.2",
       "provenance": [],
       "collapsed_sections": []
     },
@@ -15,11 +14,11 @@
   },
   "cells": [
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "UiNxsd4_q9wq",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "### What-If Tool - model comparison\n",
         "\n",
@@ -34,12 +33,12 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "qqB2tjOMETmr",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Install the What-If Tool widget if running in colab {display-mode: \"form\"}\n",
         "\n",
@@ -53,12 +52,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "jlwjF-Nnmoww",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Define helper functions {display-mode: \"form\"}\n",
         "\n",
@@ -74,11 +73,11 @@
         "        columns = df.columns.values.tolist()\n",
         "    for f in columns:\n",
         "        if df[f].dtype is np.dtype(np.int64):\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.int64)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.int64)\n",
         "        elif df[f].dtype is np.dtype(np.float64):\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.float32)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.float32)\n",
         "        else:\n",
-        "            feature_spec[f] = tf.FixedLenFeature(shape=(), dtype=tf.string)\n",
+        "            feature_spec[f] = tf.io.FixedLenFeature(shape=(), dtype=tf.string)\n",
         "    return feature_spec\n",
         "\n",
         "# Creates simple numeric and categorical feature columns from a feature spec and a\n",
@@ -114,7 +113,7 @@
         "\n",
         "# Parses Tf.Example protos into features for the input function.\n",
         "def parse_tf_example(example_proto, label, feature_spec):\n",
-        "    parsed_features = tf.parse_example(serialized=example_proto, features=feature_spec)\n",
+        "    parsed_features = tf.io.parse_example(serialized=example_proto, features=feature_spec)\n",
         "    target = parsed_features.pop(label)\n",
         "    return parsed_features, target\n",
         "\n",
@@ -144,12 +143,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "nu398ARdeuxe",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Read training dataset from CSV {display-mode: \"form\"}\n",
         "\n",
@@ -174,12 +173,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "67DYIFxoevt2",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Specify input columns and column to predict {display-mode: \"form\"}\n",
         "import numpy as np\n",
@@ -206,12 +205,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "BV4f_4_Lex22",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Convert dataset to tf.Example protos {display-mode: \"form\"}\n",
         "\n",
@@ -221,17 +220,16 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "YyLr-_0de1Ii",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Create and train the linear classifier {display-mode: \"form\"}\n",
         "\n",
         "num_steps = 2000  #@param {type: \"number\"}\n",
-        "tf.logging.set_verbosity(tf.logging.DEBUG)\n",
         "\n",
         "# Create a feature spec for the classifier\n",
         "feature_spec = create_feature_spec(df, features_and_labels)\n",
@@ -246,15 +244,14 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "EbZuyaJsufkz",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Create and train the DNN classifier {display-mode: \"form\"}\n",
-        "tf.logging.set_verbosity(tf.logging.DEBUG)\n",
         "num_steps_2 = 2000  #@param {type: \"number\"}\n",
         "\n",
         "classifier2 = tf.estimator.DNNClassifier(\n",
@@ -266,12 +263,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "NUQVro76e38Q",
         "colab_type": "code",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "#@title Invoke What-If Tool for test data and the trained models {display-mode: \"form\"}\n",
         "\n",
@@ -298,11 +295,11 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "wez70n72Q5lM",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "#### Exploration ideas\n",
         "\n",

--- a/WIT_Toxicity_Text_Model_Comparison.ipynb
+++ b/WIT_Toxicity_Text_Model_Comparison.ipynb
@@ -33,6 +33,8 @@
         "\n",
         "It also shows use of a user-provided custom distance function (for counterfactual analysis and datapoint similarity visualizations). The [tf.Hub Universal Sentence Encoder](https://tfhub.dev/google/universal-sentence-encoder/2) is used to compute the similarity of the input text comments.\n",
         "\n",
+        "This notebook is only compatible with TensorFlow 2.0.0 and later versions.\n",
+        "\n",
         "##WARNING: Some text examples in this notebook include profanity, offensive statements, and offensive statements involving identity terms. Please feel free to avoid using this notebook.\n"
       ]
     },
@@ -49,7 +51,7 @@
         "# If running in colab then pip install, otherwise no need.\n",
         "try:\n",
         "  import google.colab\n",
-        "  !pip install --upgrade witwidget\n",
+        "  !pip install --upgrade tensorflow>=2.0.0 witwidget \n",
         "except Exception:\n",
         "  pass"
       ],
@@ -61,7 +63,7 @@
       "metadata": {
         "id": "EBOHfrOP7Iy5",
         "colab_type": "code",
-        "cellView": "form",
+        "cellView": "both",
         "colab": {}
       },
       "source": [
@@ -84,25 +86,25 @@
       "metadata": {
         "id": "zZR3i6UZlZ96",
         "colab_type": "code",
-        "cellView": "form",
+        "cellView": "both",
         "colab": {}
       },
       "source": [
         "#@title Load the keras models\n",
         "import sys\n",
-        "from keras.models import load_model\n",
+        "import tensorflow as tf\n",
         "from six.moves import cPickle as pkl\n",
         "\n",
         "def pkl_load(f):\n",
         "  return pkl.load(f) if sys.version_info < (3, 0) else pkl.load(\n",
         "    f, encoding='latin1')\n",
         "\n",
-        "model1 = load_model('cnn_wiki_tox_v3_model.h5')\n",
+        "model1 = tf.keras.models.load_model('cnn_wiki_tox_v3_model.h5')\n",
         "with open('cnn_wiki_tox_v3_tokenizer.pkl', 'rb') as f:\n",
         "  tokenizer1 = pkl_load(f)\n",
         "tokenizer1.oov_token = None # quick fix for version issues\n",
         "\n",
-        "model2 = load_model('cnn_debias_tox_v3_model.h5')\n",
+        "model2 = tf.keras.models.load_model('cnn_debias_tox_v3_model.h5')\n",
         "with open('cnn_debias_tox_v3_tokenizer.pkl', 'rb') as f:\n",
         "  tokenizer2 = pkl_load(f)\n",
         "tokenizer2.oov_token = None # quick fix for version issues"
@@ -115,12 +117,12 @@
       "metadata": {
         "id": "nStoYhqT80WH",
         "colab_type": "code",
-        "cellView": "form",
+        "cellView": "both",
         "colab": {}
       },
       "source": [
         "#@title Define custom prediction functions so that WIT infers using keras models\n",
-        "from keras.preprocessing.sequence import pad_sequences\n",
+        "import tensorflow as tf\n",
         "\n",
         "# Set up model helper functions:\n",
         "PADDING_LEN = 250\n",
@@ -138,7 +140,8 @@
         "  # Tokenize string into fixed length sequence of integer based on tokenizer \n",
         "  # and model padding\n",
         "  text_sequences = tokenizer.texts_to_sequences(texts)\n",
-        "  model_ins = pad_sequences(text_sequences, maxlen=PADDING_LEN)\n",
+        "  model_ins = tf.keras.preprocessing.sequence.pad_sequences(\n",
+        "      text_sequences, maxlen=PADDING_LEN)\n",
         "  return model_ins\n",
         "\n",
         "# WIT predict functions:\n",
@@ -160,7 +163,7 @@
       "metadata": {
         "id": "NXaUORW0DVhg",
         "colab_type": "code",
-        "cellView": "form",
+        "cellView": "both",
         "colab": {}
       },
       "source": [
@@ -256,9 +259,7 @@
         "import tensorflow as tf\n",
         "import tensorflow_hub as hub\n",
         "\n",
-        "embed = hub.Module(\"https://tfhub.dev/google/universal-sentence-encoder/2\")\n",
-        "session = tf.Session()\n",
-        "session.run([tf.global_variables_initializer(), tf.tables_initializer()])\n",
+        "embed = hub.load(\"https://tfhub.dev/google/universal-sentence-encoder/4\")\n",
         "\n",
         "# For this use-case, we set distance between datapoints to be cosine distance\n",
         "# between unit-normalized embeddings of each datapoint from the tf.Hub\n",
@@ -278,10 +279,11 @@
         "                            [multiply[0], tf.shape(input_emb)[0]])\n",
         "  \n",
         "  # Compute cosine distance from input example to all examples.\n",
-        "  distances = tf.losses.cosine_distance(\n",
-        "      sentences_emb, input_matrix, axis=1, reduction=tf.losses.Reduction.NONE)\n",
-        "  results = session.run(tf.squeeze(distances))\n",
-        "  return results.tolist()"
+        "  cosine_distance = tf.keras.losses.CosineSimilarity(\n",
+        "      axis=1, reduction=tf.losses.Reduction.NONE)\n",
+        "  distances = cosine_distance(sentences_emb, input_matrix)\n",
+        "  results = tf.squeeze(distances)\n",
+        "  return results.numpy().tolist()"
       ],
       "execution_count": 0,
       "outputs": []
@@ -330,7 +332,7 @@
       "metadata": {
         "id": "QuZjEn5qOHFH",
         "colab_type": "code",
-        "cellView": "form",
+        "cellView": "both",
         "colab": {}
       },
       "source": [


### PR DESCRIPTION
Updated all notebooks to work in tf2. All notebooks except text toxicity work in both tf1 and tf2.
Text toxicity only works in tf2, but includes ensuring tf2 is installed in its first cell. This is because its use of tf hub and keras models could not be done in a way to be compatible in both, and we want to show tf2 code moving forward.