### PR TITLE
Remove <link> usage

### DIFF
--- a/wit_dashboard/wit.html
+++ b/wit_dashboard/wit.html
@@ -16,3 +16,5 @@ limitations under the License.
 -->
 <link rel="import" href="../tf-imports/polymer.html" />
 <link rel="import" href="wit-dashboard.html" />
+<wit-dashboard local id="wit" style="display:block">
+</wit-dashboard>

--- a/witwidget/notebook/colab/wit.py
+++ b/witwidget/notebook/colab/wit.py
@@ -70,7 +70,7 @@ WIT_HTML = """
     (function() {{
       const id = {id};
       const wit = document.querySelector("#wit");
-      wit.parentElement.style.height = '{height}px';
+      wit.style.height = '{height}px';
       let mutantFeature = null;
 
       // Listeners from WIT element events which pass requests to python.
@@ -251,8 +251,9 @@ class WitWidget(base.WitWidgetBase):
     self._ctor_complete = True
 
   def _get_element_html(self):
-    return """
-      <link rel="import" href="/nbextensions/wit-widget/wit_jupyter.html">"""
+    return tf.io.gfile.GFile(
+      '/usr/local/share/jupyter/nbextensions/wit-widget/wit_jupyter.html'
+      ).read()
 
   def set_examples(self, examples):
     base.WitWidgetBase.set_examples(self, examples)

--- a/witwidget/notebook/colab/wit.py
+++ b/witwidget/notebook/colab/wit.py
@@ -64,8 +64,6 @@ output.register_callback('notebook.ComputeCustomDistance',
 
 # HTML/javascript for the WIT frontend.
 WIT_HTML = """
-  <wit-dashboard id="wit" local>
-  </wit-dashboard>
   <script>
     (function() {{
       const id = {id};

--- a/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/witwidget/notebook/jupyter/js/lib/wit.js
@@ -47,7 +47,7 @@ var WITView = widgets.DOMWidgetView.extend({
    * Loads up the WIT element.
    */
   loadAndCreateWhatIfToolElement: function() {
-    const height =
+    this.height =
       parseInt(this.model.attributes.layout.attributes.height, 10) - 20;
     const iframe = document.createElement('iframe');
 
@@ -57,18 +57,10 @@ var WITView = widgets.DOMWidgetView.extend({
       witHtmlLocation = window.__nbextension_path__ + 'wit_jupyter.html';
     }
 
-    const src = `<link rel="import" href="${witHtmlLocation}">
-    <wit-dashboard local id="wit"></wit-dashboard>
-    <script>
-      const wit = document.getElementById('wit');
-      wit.style.height = "${height}px";
-      wit.style.display = "block";
-    </script>
-    `;
     iframe.frameBorder = '0';
     iframe.style.width = '100%';
-    iframe.style.height = '100%';
-    iframe.srcdoc = src;
+    iframe.style.height = `${this.height}px`;
+    iframe.src = witHtmlLocation;
     this.el.appendChild(iframe);
     this.iframe = iframe;
 
@@ -96,6 +88,7 @@ var WITView = widgets.DOMWidgetView.extend({
    */
   setupView: function() {
     this.view_ = this.iframe.contentDocument.getElementById('wit');
+    this.view_.style.height = `${this.height}px`;
     // Add listeners for changes from WIT Polymer element. Passes changes
     // along to python.
     this.view_.addEventListener('infer-examples', (e) => {


### PR DESCRIPTION
Add wit-dashboard invocation to wit_jupyter.html so that colab and jupyter implementations can remove use of the <link> HTML import, as this is removed in upcoming Chrome M80 and due to this, witwidget never worked in Firefox and similar browsers.

With this change, and a new pip version release, witwidget will work in Chrome M80 and Firefox/Safari.