### PR TITLE
Relay the plugin registration upwards.

### DIFF
--- a/tensorboard_plugin_wit/pip_package/index.js
+++ b/tensorboard_plugin_wit/pip_package/index.js
@@ -25,6 +25,14 @@ export async function render() {
       width: 100%;
     }`;
   document.head.appendChild(style);
+
+  /**
+   * Relay the plugin registration message from inner HTML up to the TensorBoard.
+   */
+  window.addEventListener('message', (event) => {
+    window.parent.postMessage(event.data, '*', event.ports);
+  });
+
   const iframe = document.createElement('iframe');
   iframe.src = './wit_tb_bin.html';
   document.body.appendChild(iframe);


### PR DESCRIPTION
With this change, I was able to see grab the data in the URL by changing hash to `p.whatif.foo=bar` and using `await tb_plugin_lib.experimental.core.getURLPluginData()` in wit-tensorboard.html. 

![image](https://user-images.githubusercontent.com/2547313/73990312-9e6b9d80-48fd-11ea-96c7-d4bac2c3c340.png)
