### PR TITLE
Remove pip dependency on tf-serving-api

### DIFF
--- a/tensorboard_plugin_wit/pip_package/build_pip_package.sh
+++ b/tensorboard_plugin_wit/pip_package/build_pip_package.sh
@@ -62,10 +62,17 @@ cp "$plugin_runfile_dir/utils/inference_utils.py" tensorboard_plugin_wit/_utils
 cp "$plugin_runfile_dir/utils/platform_utils.py" tensorboard_plugin_wit/_utils
 touch tensorboard_plugin_wit/_utils/__init__.py
 
+mkdir -p witwidget/_vendor
+>witwidget/_vendor/__init__.py
+# Vendor tensorflow-serving-api because it depends directly on TensorFlow.
+# TODO(jameswex): de-vendor if they're able to relax that dependency.
+cp -LR "${RUNFILES}/org_tensorflow_serving_api/tensorflow_serving" witwidget/_vendor
+
 # Fix the import statements to reflect the copied over path.
 find tensorboard_plugin_wit -name \*.py |
   xargs $sedi -e '
     s/^from utils/from tensorboard_plugin_wit._utils/
+    s/from tensorflow_serving/from witwidget._vendor.tensorflow_serving/
   '
 
 virtualenv venv

--- a/tensorboard_plugin_wit/pip_package/build_pip_package.sh
+++ b/tensorboard_plugin_wit/pip_package/build_pip_package.sh
@@ -62,17 +62,17 @@ cp "$plugin_runfile_dir/utils/inference_utils.py" tensorboard_plugin_wit/_utils
 cp "$plugin_runfile_dir/utils/platform_utils.py" tensorboard_plugin_wit/_utils
 touch tensorboard_plugin_wit/_utils/__init__.py
 
-mkdir -p witwidget/_vendor
->witwidget/_vendor/__init__.py
+mkdir -p tensorboard_plugin_wit/_vendor
+>tensorboard_plugin_wit/_vendor/__init__.py
 # Vendor tensorflow-serving-api because it depends directly on TensorFlow.
 # TODO(jameswex): de-vendor if they're able to relax that dependency.
-cp -LR "${RUNFILES}/org_tensorflow_serving_api/tensorflow_serving" witwidget/_vendor
+cp -LR "${RUNFILES}/org_tensorflow_serving_api/tensorflow_serving" tensorboard_plugin_wit/_vendor
 
 # Fix the import statements to reflect the copied over path.
 find tensorboard_plugin_wit -name \*.py |
   xargs $sedi -e '
     s/^from utils/from tensorboard_plugin_wit._utils/
-    s/from tensorflow_serving/from witwidget._vendor.tensorflow_serving/
+    s/from tensorflow_serving/from tensorboard_plugin_wit._vendor.tensorflow_serving/
   '
 
 virtualenv venv

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -1261,7 +1261,7 @@ limitations under the License.
         position: absolute;
         top: 8px;
         left: 7px;
-        width: 220px;
+        width: 120px;
         --paper-progress-active-color: var(--tb-orange-strong);
       }
       #attributionLegend {

--- a/witwidget/pip_package/build_pip_package.sh
+++ b/witwidget/pip_package/build_pip_package.sh
@@ -77,10 +77,17 @@ cp "$plugin_runfile_dir/utils/inference_utils.py" witwidget/_utils
 cp "$plugin_runfile_dir/utils/platform_utils.py" witwidget/_utils
 touch witwidget/_utils/__init__.py
 
+mkdir -p witwidget/_vendor
+>witwidget/_vendor/__init__.py
+# Vendor tensorflow-serving-api because it depends directly on TensorFlow.
+# TODO(jameswex): de-vendor if they're able to relax that dependency.
+cp -LR "${RUNFILES}/org_tensorflow_serving_api/tensorflow_serving" witwidget/_vendor
+
 # Fix the import statements to reflect the copied over path.
 find witwidget -name \*.py |
   xargs $sedi -e '
     s/^from utils/from witwidget._utils/
+    s/from tensorflow_serving/from witwidget._vendor.tensorflow_serving/
   '
 
 virtualenv venv

--- a/witwidget/pip_package/setup.py
+++ b/witwidget/pip_package/setup.py
@@ -31,15 +31,13 @@ if '--project_name' in sys.argv:
 
 _TF_REQ = [
     'tensorflow>=1.12.0',
-    'tensorflow-serving-api>=1.12.0'
 ]
 
-# GPU build (note: the only difference is we depend on tensorflow-gpu and
-# tensorflow-serving-api-gpu so pip doesn't overwrite them with the CPU builds)
+# GPU build (note: the only difference is we depend on tensorflow-gpu
+# so pip doesn't overwrite it with the CPU build)
 if 'witwidget-gpu' in project_name:
   _TF_REQ = [
       'tensorflow-gpu>=1.12.0',
-      'tensorflow-serving-api-gpu>=1.12.0'
   ]
 
 REQUIRED_PACKAGES = [


### PR DESCRIPTION
In order to have WIT be a dynamic TensorBoard plugin, it can't depend on tf-serving-api pip package, since that depends on TF which depends on TB.

The solution is the same one used by TensorBoard itself, which is to vendor the tf-serving-api python code into the WIT pip packages and point the WIT code that uses those files to the internally-vendored versions.

Tested this solution with the wit tensorboard pip package in a locally-built version of TB with the dynamic plugin, ensuring that the tf-serving-api package was not installed yet WIT was still able to correctly query and get responses from a model served by tf-serving.

Changes to build_pip_package.sh taken directly from TensorBoard versions of that file.