### PR TITLE
Add plugin loader for WIT TB plugin

### DIFF
--- a/tensorboard_plugin_wit/BUILD
+++ b/tensorboard_plugin_wit/BUILD
@@ -20,6 +20,16 @@ py_library(
     ],
 )
 
+py_library(
+    name = "wit_plugin_loader",
+    srcs = ["wit_plugin_loader.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":wit_plugin",
+        "@org_tensorflow_tensorboard//tensorboard/plugins:base_plugin",
+    ],
+)
+
 py_test(
     name = "wit_plugin_test",
     size = "small",

--- a/tensorboard_plugin_wit/pip_package/BUILD
+++ b/tensorboard_plugin_wit/pip_package/BUILD
@@ -18,7 +18,7 @@ sh_binary(
         "setup.py",
         ":assets", # For HTML payload
         "//utils:inference_utils",  # Utility method that visualization code uses.
-        "//tensorboard_plugin_wit:wit_plugin",  # WIT TensorBoard plugin code
+        "//tensorboard_plugin_wit:wit_plugin_loader",  # WIT TensorBoard plugin code
     ],
     tags = [
         "local",

--- a/tensorboard_plugin_wit/pip_package/setup.py
+++ b/tensorboard_plugin_wit/pip_package/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     },
     entry_points={
         "tensorboard_plugins": [
-            "wit = tensorboard_plugin_wit.wit_plugin:WhatIfToolPlugin",
+            "wit = tensorboard_plugin_wit.wit_plugin_loader:WhatIfToolPluginLoader",
         ],
     },
 )

--- a/tensorboard_plugin_wit/wit_plugin_loader.py
+++ b/tensorboard_plugin_wit/wit_plugin_loader.py
@@ -1,0 +1,43 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Wrapper around plugin to conditionally enable it."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard.plugins import base_plugin
+
+
+class WhatIfToolPluginLoader(base_plugin.TBLoader):
+    """WhatIfToolPlugin factory.
+    This class checks for `tensorflow` install and dependency.
+    """
+
+    def load(self, context):
+        """Returns the plugin, if possible.
+        Args:
+          context: The TBContext flags.
+        Returns:
+          A WhatIfToolPlugin instance or None if it couldn't be loaded.
+        """
+        try:
+            # pylint: disable=unused-import
+            import tensorflow
+        except ImportError:
+            return
+        from tensorboard_plugin_wit.wit_plugin import WhatIfToolPlugin
+
+        return WhatIfToolPlugin(context)


### PR DESCRIPTION
The tensorboard-plugin-wit package as-is doesn't work with TensorBoard, because as part of their tests TensorBoard needs to be able to run (with limited capabilities) in environments without TensorFlow installed, but the WIT plugin requires TensorFlow installed.

This was solved with the non-dynamic-plugin WIT TensorBoard code through a TBPluginLoader (https://github.com/tensorflow/tensorboard/blob/9db185d058de97fa8b1f3ba151ad7c762d877540/tensorboard/plugins/interactive_inference/interactive_inference_plugin_loader.py).

This PR adds this same loader capability to the dynamic plugin.

Tested with TensorFlow installed in my local build and ensured it works as it did before this PR. 

Tested without TF installed through the TB CI process in https://github.com/tensorflow/tensorboard/pull/3242