### PR TITLE
Allow models to return classification by label instead of index

### DIFF
--- a/wit_dashboard/demo/wit-demo.html
+++ b/wit_dashboard/demo/wit-demo.html
@@ -51,6 +51,8 @@ limitations under the License.
         labelVocab: {type: Array, value: ['<=50k', '>50k']},
       },
       ready: async function() {
+        this.$.dash.modelName = '1';
+        this.$.dash.inferenceAddress = 'demo1';
         this.$.dash.updateNumberOfModels();
         this.means = {
           age: 38.64358543876172,
@@ -235,8 +237,8 @@ limitations under the License.
             for (let i = 0; i < indices.length; i++) {
               inferences.results[0].classificationResult.classifications[i] = {
                 classes: [
-                  {label: '0', score: predValues[i * PRED_SIZE + 1]},
-                  {label: '1', score: predValues[i * PRED_SIZE]},
+                  {label: '<=50k', score: predValues[i * PRED_SIZE + 1]},
+                  {label: '>50k', score: predValues[i * PRED_SIZE]},
                 ],
               };
             }
@@ -501,7 +503,7 @@ limitations under the License.
             : [atob(ex.features.feature[featureName].bytesList.value[0])];
           results.push({step: step, scalar: score});
         }
-        return [[{'1': results}]];
+        return [[{'>50k': results}]];
       },
       convertExToTensor: function(ex) {
         const vals = [];

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -7943,7 +7943,14 @@ limitations under the License.
                 modelInd,
                 data.length
               );
-              const thresholdData = data[0][_.keys(data[0])].map((point) => {
+              let keys = _.keys(data[0]);
+              // If using a label vocab, then adjust the keys to get the right
+              // label for the positive class.
+              if (keys.length > 1 && this.labelVocab &&
+                  this.labelVocab.length > 1) {
+                keys = [this.labelVocab[1]];
+              }
+              const thresholdData = data[0][keys].map((point) => {
                 return {
                   step: point.step,
                   scalar: this.overallThresholds[modelInd].threshold,
@@ -7989,7 +7996,16 @@ limitations under the License.
         createPdEntryForCurrentValue: function(featureName, data, modelInd) {
           // Extract the class and feature value index from the key of the PD
           // chart data .
-          const key = _.keys(data)[0];
+          const keys = _.keys(data);
+          let key = keys[0];
+          // If using a label vocab, then adjust the key to get the right
+          // label for the positive class.
+          if (this.labelVocab && this.labelVocab.length > 1) {
+            const possibleLabelKey = keys.indexOf(this.labelVocab[1]);
+            if (possibleLabelKey !== -1) {
+              key = [1];
+            }
+          }
           const indexOfIndexStr = key.indexOf('index');
           let classToChart = +key;
           let indexForValue = 0;

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -6441,15 +6441,26 @@ limitations under the License.
               ) {
                 const result = this.inferences.results[modelNum]
                   .classificationResult;
-                // For models that don't return any labels for the classes, fill
-                // them out with class indices.
                 for (
                   let j = 0;
                   j < result.classifications[i].classes.length;
                   j++
                 ) {
+                  // For models that don't return any labels for the classes,
+                  // fill them out with class indices.
                   if (result.classifications[i].classes[j].label == '') {
                     result.classifications[i].classes[j].label = j.toString();
+                  }
+                  // If the label matches a string from the label vocab, then
+                  // replace the label with the class index as that is what
+                  // WIT expects.
+                  if (this.labelVocab != null && this.labelVocab.length > 0) {
+                    const labelIndex = this.labelVocab.indexOf(
+                      result.classifications[i].classes[j].label);
+                    if (labelIndex !== -1) {
+                      result.classifications[i].classes[j].label =
+                        labelIndex.toString();
+                    }
                   }
                 }
                 inferenceMap[this.inferences.indices[i]][

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -7945,7 +7945,13 @@ limitations under the License.
               );
               let keys = _.keys(data[0]);
               // If using a label vocab, then adjust the keys to get the right
-              // label for the positive class.
+              // label for the positive class. Keys is normally of size 1 as
+              // only partial dependence plot info for the positive class in
+              // binary classification is returned by the server. But in some
+              // cases, there may be entries for both positive and negative
+              // classes. In this case, if there is a label vocab, use it
+              // to filter out the keys to only use the one for the positive
+              // class, which is array index 1 in the label vocab.
               if (keys.length > 1 && this.labelVocab &&
                   this.labelVocab.length > 1) {
                 keys = [this.labelVocab[1]];
@@ -7995,11 +8001,13 @@ limitations under the License.
          */
         createPdEntryForCurrentValue: function(featureName, data, modelInd) {
           // Extract the class and feature value index from the key of the PD
-          // chart data .
+          // chart data. In the standard case, we just need to look at the
+          // first entry to find the initial value.
           const keys = _.keys(data);
           let key = keys[0];
           // If using a label vocab, then adjust the key to get the right
-          // label for the positive class.
+          // label for the positive class. In this case, the second entry
+          // corresponds to the positive class.
           if (this.labelVocab && this.labelVocab.length > 1) {
             const possibleLabelKey = keys.indexOf(this.labelVocab[1]);
             if (possibleLabelKey !== -1) {


### PR DESCRIPTION
If a model from a model server returns class labels as string labels instead of class indices, WIT breaks. But in that case, if the user provides a label vocab, we can use it to map returned class labels to their indices, and un-break WIT in this case.

Updated:
- initial inference collection logic to handle classification by label from label vocab
- pd plot creation to handle inference results with label from label vocab
- one of the demos to return results in this format, for easy testing