### PR TITLE
Move colabs to py3 kernels

### DIFF
--- a/WIT_Age_Regression.ipynb
+++ b/WIT_Age_Regression.ipynb
@@ -8,8 +8,8 @@
       "collapsed_sections": []
     },
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
+      "name": "python3",
+      "display_name": "Python 3"
     }
   },
   "cells": [

--- a/WIT_COMPAS.ipynb
+++ b/WIT_COMPAS.ipynb
@@ -8,8 +8,8 @@
       "collapsed_sections": []
     },
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
+      "name": "python3",
+      "display_name": "Python 3"
     }
   },
   "cells": [

--- a/WIT_Model_Comparison.ipynb
+++ b/WIT_Model_Comparison.ipynb
@@ -8,8 +8,8 @@
       "collapsed_sections": []
     },
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
+      "name": "python3",
+      "display_name": "Python 3"
     }
   },
   "cells": [

--- a/WIT_Smile_Detector.ipynb
+++ b/WIT_Smile_Detector.ipynb
@@ -9,8 +9,8 @@
       "collapsed_sections": []
     },
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
+      "name": "python3",
+      "display_name": "Python 3"
     }
   },
   "cells": [

--- a/What_If_Tool_Notebook_Usage.ipynb
+++ b/What_If_Tool_Notebook_Usage.ipynb
@@ -9,8 +9,8 @@
       "collapsed_sections": []
     },
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
+      "name": "python3",
+      "display_name": "Python 3"
     }
   },
   "cells": [


### PR DESCRIPTION
py2 colab kernel is deprecated and no longer works correctly with WIT.