### PR TITLE
Fix type error for sprite generation for images

### DIFF
--- a/utils/inference_utils.py
+++ b/utils/inference_utils.py
@@ -757,7 +757,7 @@ def create_sprite_image(examples):
         top_start = top_idx * thumb_height
         top_end = top_start + thumb_height
         master[top_start:top_end, left_start:left_end, :] = image
-      return tf.image.encode_png(master)
+      return tf.image.encode_png(tf.cast(master, dtype=tf.uint8))
 
     image_feature_name = 'image/encoded'
     sprite_thumbnail_dim_px = 32


### PR DESCRIPTION
This PR fixes an error when creating sprite for image data due to data type mismatch.
tf.image.encode_png only accepts uint8 or uint16, whereas we were passing float. Something may have changed in TF1->TF2 update that removed auto type conversion as this code used to work before.

Tested smile demo in colab to verify the fix works.