### PR TITLE
Update global attributions table styling

### DIFF
--- a/wit_dashboard/wit-attribution-table.html
+++ b/wit_dashboard/wit-attribution-table.html
@@ -81,6 +81,7 @@ limitations under the License.
         attributions: Array,
         models: Array,
         colors: Object,
+        textColorFunction: Object,
       },
       displayNum: function(num) {
         return d3.format('.3f')(num);
@@ -97,24 +98,10 @@ limitations under the License.
         if (this.colors == null) {
           return '';
         }
-        const backgroundColor = this.colors(num);
-        const useLightText = (num) => {
-          const domain = this.colors.domain();
-          const minVal = domain[0];
-          const maxVal = domain[domain.length - 1];
-          const percentile = (num - minVal) / (maxVal - minVal);
-          if (minVal < 0 && maxVal > 0) {
-            return percentile < 0.3 || percentile > 0.7;
-          } else if (minVal < 0) {
-            return percentile < 0.6;
-          } else {
-            return percentile > 0.4;
-          }
-        };
-
-        return 'background-color:' +
-          (this.colors == null ? 'white' : this.colors(num) +
-          ';color:' + (useLightText(num) ? 'white' : '#202124'));
+        const domain = this.colors.domain();
+        return 'background-color:' + this.colors(num) +
+          ';color:' + this.textColorFunction(
+            num, domain[0], domain[domain.length - 1]);
       },
     });
   </script>

--- a/wit_dashboard/wit-attribution-table.html
+++ b/wit_dashboard/wit-attribution-table.html
@@ -22,7 +22,8 @@ limitations under the License.
     <style>
       table {
         display: inline-block;
-        font-size: 14px;
+        font-size: 11px;
+        color: #202124;
       }
       th {
         color: #80868b;
@@ -30,20 +31,28 @@ limitations under the License.
         padding: 3px;
       }
       td {
-        font-size: 14px;
-        padding: 3px;
+        padding: 3px 6px;
       }
       .holder {
         display: flex;
+        margin-bottom: 12px;
       }
       .table-holder {
         padding-right: 8px;
+        max-height: 200px;
+        overflow-y: scroll;
       }
       .feature {
         text-align: left;
       }
       .value {
         text-align: right;
+      }
+      .label {
+        font-size: 10px;
+      }
+      .cell {
+        border: 1px solid lightgrey;
       }
     </style>
     <div class="holder">
@@ -56,8 +65,8 @@ limitations under the License.
             </tr>
             <template is="dom-repeat" items="[[table]]">
               <tr>
-                <td class="feature">[[item.key]]</td>
-                <td class="value">[[displayNum(item.mean)]]</td>
+                <td class="feature label">[[item.key]]</td>
+                <td class="value cell" style$="[[getStyle(item.mean)]]">[[displayNum(item.mean)]]</td>
               </tr>
             </template>
           </table>
@@ -71,17 +80,41 @@ limitations under the License.
       properties: {
         attributions: Array,
         models: Array,
+        colors: Object,
       },
       displayNum: function(num) {
         return d3.format('.3f')(num);
       },
       displayAttributionHeader: function(models, index) {
-        let str = 'attribution';
         if (models != null && models.length > 1) {
           const modelName = models[index];
-          str += ` (model ${modelName})`;
+          return `Model ${modelName}`;
+        } else {
+          return 'Attribution';
         }
-        return str;
+      },
+      getStyle: function(num) {
+        if (this.colors == null) {
+          return '';
+        }
+        const backgroundColor = this.colors(num);
+        const useLightText = (num) => {
+          const domain = this.colors.domain();
+          const minVal = domain[0];
+          const maxVal = domain[domain.length - 1];
+          const percentile = (num - minVal) / (maxVal - minVal);
+          if (minVal < 0 && maxVal > 0) {
+            return percentile < 0.3 || percentile > 0.7;
+          } else if (minVal < 0) {
+            return percentile < 0.6;
+          } else {
+            return percentile > 0.4;
+          }
+        };
+
+        return 'background-color:' +
+          (this.colors == null ? 'white' : this.colors(num) +
+          ';color:' + (useLightText(num) ? 'white' : '#202124'));
       },
     });
   </script>

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -564,6 +564,7 @@ limitations under the License.
         flex-wrap: wrap;
         margin: 4px;
         position: relative;
+        padding-left: 28px;
       }
 
       .perf-holder {
@@ -1800,6 +1801,7 @@ limitations under the License.
                             max-sal="[[maxAttribution]]"
                             colors="[[attributionColorScale]]"
                             highlight-differences="[[showNearestCounterfactual]]"
+                            text-color-function="[[attributionTextColorFunction]]"
                           >
                           </wit-example-viewer>
                         </div>
@@ -2886,7 +2888,8 @@ limitations under the License.
                                   <wit-attribution-table
                                     attributions="[[getFacetedAttributions(facetedMeanAttributions_, featureValueThreshold)]]"
                                     models="[[parsedModelNames]]"
-                                    colors="[[attributionColorScale]]">
+                                    colors="[[attributionColorScale]]"
+                                    text-color-function="[[attributionTextColorFunction]]">
                                   </wit-attribution-table>
                                 </div>
                               </template>
@@ -3134,7 +3137,8 @@ limitations under the License.
                                 <wit-attribution-table
                                   attributions="[[meanAttributions_]]"
                                   models="[[parsedModelNames]]"
-                                  colors="[[attributionColorScale]]">
+                                  colors="[[attributionColorScale]]"
+                                  text-color-function="[[attributionTextColorFunction]]">
                                 </wit-attribution-table>
                               </div>
                             </template>
@@ -3470,7 +3474,8 @@ limitations under the License.
                                 <wit-attribution-table
                                   attributions="[[getFacetedAttributions(facetedMeanAttributions_, featureValueThreshold)]]"
                                   models="[[parsedModelNames]]"
-                                  colors="[[attributionColorScale]]">
+                                  colors="[[attributionColorScale]]"
+                                  text-color-function="[[attributionTextColorFunction]]">
                                 </wit-attribution-table>
                               </div>
                             </div>
@@ -3692,7 +3697,8 @@ limitations under the License.
                               <wit-attribution-table
                                 attributions="[[meanAttributions_]]"
                                 models="[[parsedModelNames]]"
-                                colors="[[attributionColorScale]]">
+                                colors="[[attributionColorScale]]"
+                                text-color-function="[[attributionTextColorFunction]]">
                               </wit-attribution-table>
                             </div>
                           </div>
@@ -3832,7 +3838,8 @@ limitations under the License.
                             <wit-attribution-table
                               attributions="[[getRegressionAttributions(item.name)]]"
                               models="[[parsedModelNames]]"
-                              colors="[[attributionColorScale]]">
+                              colors="[[attributionColorScale]]"
+                              text-color-function="[[attributionTextColorFunction]]">
                             </wit-attribution-table>
                           </div>
                         </template>
@@ -3889,6 +3896,8 @@ limitations under the License.
     const COLOR_INTERPOLATOR = d3.interpolateRgb;
     const LEGEND_WIDTH_PX = 160;
     const LEGEND_HEIGHT_PX = 8;
+    const defaultTextColor = '#3c4043';
+    const lightTextColor = '#fff';
 
     function deleteElement(elt) {
       if (elt && elt.parentElement) {
@@ -4434,6 +4443,25 @@ limitations under the License.
           featureBucketEdges_: {
             type: Object,
             value: () => ({}),
+          },
+          // Function to get text colors for attribution values, to be passed
+          // to child components that render such text.
+          attributionTextColorFunction: {
+            type: Object,
+            value: () => {
+              return function(saliency, minSal, maxSal) {
+                const percentile = (saliency - minSal) / (maxSal - minSal);
+                let useLightColor = false;
+                if (minSal < 0 && maxSal > 0) {
+                  useLightColor = percentile < 0.3 || percentile > 0.7;
+                } else if (this.minSal < 0) {
+                  useLightColor = percentile < 0.6;
+                } else {
+                  useLightColor = percentile > 0.4;
+                }
+                return useLightColor ? lightTextColor : defaultTextColor;
+              };
+            }
           },
         },
 

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -856,6 +856,12 @@ limitations under the License.
         margin-left: 5px;
       }
 
+      .info-icon.mean-attrs-info-icon {
+        margin-top: -1px;
+        margin-bottom: 10px;
+        margin-left: 5px;
+      }
+
       .info-icon.performance-info-icon {
         margin-top: 18px;
         margin-bottom: 10px;
@@ -911,14 +917,14 @@ limitations under the License.
 
       .perf-curve-text {
         color: #3c4043;
-        font-size: 16px;
+        font-size: 14px;
         margin-bottom: -10px;
       }
 
       .conf-text {
         margin-bottom: 8px;
         color: #3c4043;
-        font-size: 16px;
+        font-size: 14px;
       }
 
       .dialog-text {
@@ -1097,6 +1103,7 @@ limitations under the License.
         border-radius: 2px;
         background: white;
         position: relative;
+        padding-bottom: 8px;
       }
 
       .regression-perf-table-entry {
@@ -1111,6 +1118,11 @@ limitations under the License.
         display: flex;
         background: white;
         position: relative;
+      }
+
+      .feature-name-text {
+        font-weight: 500;
+        font-size: 14px;
       }
 
       .perf-table-text-entry {
@@ -1230,6 +1242,10 @@ limitations under the License.
       }
       .rotated-icon {
         transform: rotate(270deg);
+        padding-right: 0;
+      }
+      .normal-icon {
+        padding-top: 0;
       }
       .datapoint-control-button {
         width: 28px;
@@ -2617,7 +2633,7 @@ limitations under the License.
                             ></paper-icon-button>
                           </div>
                           <div
-                            class="perf-table-val perf-table-clickable perf-table-text-entry"
+                            class="perf-table-val perf-table-clickable perf-table-text-entry feature-name-text"
                             on-tap="togglePerfRow"
                           >
                             [[getPrintableValue_(featureValueThreshold)]]
@@ -2806,7 +2822,27 @@ limitations under the License.
                                   </vz-line-chart2>
                                 </div>
                                 <div class="perf-holder">
-                                  <div class="conf-text">Confusion matrix</div>
+                                  <div class="flex">
+                                    <div class="conf-text">Confusion Matrix</div>
+                                    <paper-icon-button
+                                      icon="info-outline"
+                                      class="info-icon mean-attrs-info-icon no-padding"
+                                      on-tap="openDialog"
+                                    >
+                                    </paper-icon-button>
+                                    <paper-dialog
+                                      class="dialog-text"
+                                      horizontal-align="auto"
+                                      vertical-align="auto"
+                                    >
+                                      <div class="dialog-title">
+                                          Confusion Matrix
+                                      </div>
+                                      <div>
+                                          A confusion matrix is a n*n table (where n = number of classes being predicted) that summarizes if a model’s predictions were correct or incorrect. One axis is the model’s predictions, and the other axis is the ground truth.
+                                      </div>
+                                    </paper-dialog>
+                                  </div>
                                   <template
                                     is="dom-repeat"
                                     items="{{featureValueThreshold.threshold}}"
@@ -2830,7 +2866,7 @@ limitations under the License.
                                     <div class="conf-text">Mean attributions</div>
                                     <paper-icon-button
                                       icon="info-outline"
-                                      class="info-icon threshold-info-icon no-padding"
+                                      class="info-icon mean-attrs-info-icon no-padding"
                                       on-tap="openDialog"
                                     >
                                     </paper-icon-button>
@@ -2869,10 +2905,11 @@ limitations under the License.
                             <paper-icon-button
                               icon="arrow-drop-down"
                               on-tap="togglePerfRow"
+                              class="normal-icon"
                               disabled
                             ></paper-icon-button>
                           </div>
-                          <div class="perf-table-val perf-table-text-entry">
+                          <div class="perf-table-val perf-table-text-entry feature-name-text">
                             All datapoints
                           </div>
                           <div class="perf-table-count perf-table-num-entry">
@@ -3033,7 +3070,27 @@ limitations under the License.
                                 </vz-line-chart2>
                               </div>
                               <div class="perf-holder">
-                                <div class="conf-text">Confusion matrix</div>
+                                <div class="flex">
+                                  <div class="conf-text">Confusion Matrix</div>
+                                  <paper-icon-button
+                                    icon="info-outline"
+                                    class="info-icon mean-attrs-info-icon no-padding"
+                                    on-tap="openDialog"
+                                  >
+                                  </paper-icon-button>
+                                  <paper-dialog
+                                    class="dialog-text"
+                                    horizontal-align="auto"
+                                    vertical-align="auto"
+                                  >
+                                    <div class="dialog-title">
+                                        Confusion Matrix
+                                    </div>
+                                    <div>
+                                        A confusion matrix is a n*n table (where n = number of classes being predicted) that summarizes if a model’s predictions were correct or incorrect. One axis is the model’s predictions, and the other axis is the ground truth.
+                                    </div>
+                                  </paper-dialog>
+                                </div>
                                 <template
                                   is="dom-repeat"
                                   items="{{overallThresholds}}"
@@ -3057,7 +3114,7 @@ limitations under the License.
                                   <div class="conf-text">Mean attributions</div>
                                   <paper-icon-button
                                     icon="info-outline"
-                                    class="info-icon threshold-info-icon no-padding"
+                                    class="info-icon mean-attrs-info-icon no-padding"
                                     on-tap="openDialog"
                                   >
                                   </paper-icon-button>
@@ -3188,7 +3245,7 @@ limitations under the License.
                             ></paper-icon-button>
                           </div>
                           <div
-                            class="perf-table-val perf-table-clickable perf-table-text-entry"
+                            class="perf-table-val perf-table-clickable perf-table-text-entry feature-name-text"
                             on-tap="togglePerfRow"
                           >
                             [[getPrintableValue_(featureValueThreshold)]]
@@ -3243,7 +3300,27 @@ limitations under the License.
                           >
                             <div class="perfs-holder">
                               <div class="perf-holder">
-                                <div class="conf-text">Confusion matrix</div>
+                                <div class="flex">
+                                  <div class="conf-text">Confusion Matrix</div>
+                                  <paper-icon-button
+                                    icon="info-outline"
+                                    class="info-icon mean-attrs-info-icon no-padding"
+                                    on-tap="openDialog"
+                                  >
+                                  </paper-icon-button>
+                                  <paper-dialog
+                                    class="dialog-text"
+                                    horizontal-align="auto"
+                                    vertical-align="auto"
+                                  >
+                                    <div class="dialog-title">
+                                        Confusion Matrix
+                                    </div>
+                                    <div>
+                                        A confusion matrix is a n*n table (where n = number of classes being predicted) that summarizes if a model’s predictions were correct or incorrect. One axis is the model’s predictions, and the other axis is the ground truth.
+                                    </div>
+                                  </paper-dialog>
+                                </div>
                                 <template
                                   is="dom-repeat"
                                   items="[[inferenceStats_]]"
@@ -3373,7 +3450,7 @@ limitations under the License.
                                   <div class="conf-text">Mean attributions</div>
                                   <paper-icon-button
                                     icon="info-outline"
-                                    class="info-icon threshold-info-icon no-padding"
+                                    class="info-icon mean-attrs-info-icon no-padding"
                                     on-tap="openDialog"
                                   >
                                   </paper-icon-button>
@@ -3411,10 +3488,11 @@ limitations under the License.
                             <paper-icon-button
                               icon="arrow-drop-down"
                               on-tap="togglePerfRow"
+                              class="normal-icon"
                               disabled
                             ></paper-icon-button>
                           </div>
-                          <div class="perf-table-val perf-table-text-entry">
+                          <div class="perf-table-val perf-table-text-entry feature-name-text">
                             All datapoints
                           </div>
                           <div class="perf-table-count perf-table-num-entry">
@@ -3455,7 +3533,27 @@ limitations under the License.
                         >
                           <div class="perfs-holder">
                             <div class="perf-holder">
-                              <div class="conf-text">Confusion matrix</div>
+                              <div class="flex">
+                                <div class="conf-text">Confusion Matrix</div>
+                                <paper-icon-button
+                                  icon="info-outline"
+                                  class="info-icon mean-attrs-info-icon no-padding"
+                                  on-tap="openDialog"
+                                >
+                                </paper-icon-button>
+                                <paper-dialog
+                                  class="dialog-text"
+                                  horizontal-align="auto"
+                                  vertical-align="auto"
+                                >
+                                  <div class="dialog-title">
+                                      Confusion Matrix
+                                  </div>
+                                  <div>
+                                      A confusion matrix is a n*n table (where n = number of classes being predicted) that summarizes if a model’s predictions were correct or incorrect. One axis is the model’s predictions, and the other axis is the ground truth.
+                                  </div>
+                                </paper-dialog>
+                              </div>
                               <template
                                 is="dom-repeat"
                                 items="[[inferenceStats_]]"
@@ -3574,7 +3672,7 @@ limitations under the License.
                                 <div class="conf-text">Mean attributions</div>
                                 <paper-icon-button
                                   icon="info-outline"
-                                  class="info-icon threshold-info-icon no-padding"
+                                  class="info-icon mean-attrs-info-icon no-padding"
                                   on-tap="openDialog"
                                 >
                                 </paper-icon-button>
@@ -3669,7 +3767,7 @@ limitations under the License.
                       <div class="regression-perf-table-entry">
                         <div class="regression-perf-table-row">
                           <div class="perf-table-arrow"></div>
-                          <div class="perf-table-val perf-table-text-entry">
+                          <div class="perf-table-val perf-table-text-entry feature-name-text">
                             [[item.name]]
                           </div>
                           <div
@@ -3714,7 +3812,7 @@ limitations under the License.
                               <div class="conf-text">Mean attributions</div>
                               <paper-icon-button
                                 icon="info-outline"
-                                class="info-icon threshold-info-icon no-padding"
+                                class="info-icon mean-attrs-info-icon no-padding"
                                 on-tap="openDialog"
                               >
                               </paper-icon-button>

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -560,7 +560,6 @@ limitations under the License.
 
       .perfs-holder {
         display: flex;
-        justify-content: center;
         width: 100%;
         flex-wrap: wrap;
         margin: 4px;
@@ -574,6 +573,7 @@ limitations under the License.
 
       .regression-attr-holder {
         padding-left: 48px;
+        position: relative;
       }
 
       .perf-curve-x-label {
@@ -912,7 +912,6 @@ limitations under the License.
       .perf-curve-text {
         color: #3c4043;
         font-size: 16px;
-        margin-left: 44px;
         margin-bottom: -10px;
       }
 
@@ -1067,7 +1066,6 @@ limitations under the License.
         background: white;
         color: #3c4043;
         font-size: 14px;
-        border-bottom: solid 1px var(--wit-color-gray300);
       }
 
       .perf-table-entry.perf-table-entry-trivial {
@@ -1078,7 +1076,6 @@ limitations under the License.
         display: flex;
         flex-wrap: wrap;
         width: 100%;
-        margin: 0 12px;
         border-left: 1px solid var(--wit-color-gray300);
         border-bottom: 1px solid var(--wit-color-gray300);
         border-right: 1px solid var(--wit-color-gray300);
@@ -1090,16 +1087,28 @@ limitations under the License.
         display: flex;
         background: white;
         position: relative;
+        border-bottom: solid 1px var(--wit-color-gray300);
       }
 
       .perf-table-row-expanded {
         width: 100%;
         display: flex;
-        border-bottom: 1px solid var(--wit-color-gray300);
         border-top: 1px solid var(--wit-color-gray300);
         border-radius: 2px;
-        box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.3),
-          0 1px 3px 1px rgba(60, 64, 67, 0.15);
+        background: white;
+        position: relative;
+      }
+
+      .regression-perf-table-entry {
+        background: white;
+        color: #3c4043;
+        font-size: 14px;
+        border-bottom: solid 1px var(--wit-color-gray300);
+      }
+
+      .regression-perf-table-row {
+        width: 100%;
+        display: flex;
         background: white;
         position: relative;
       }
@@ -2817,8 +2826,31 @@ limitations under the License.
                                 if="[[hasAttributions_(attributions)]]"
                               >
                                 <div class="perf-holder">
-                                  <div class="conf-text">Mean attributions</div>
-                                  <wit-attribution-table attributions="[[getFacetedAttributions(facetedMeanAttributions_, featureValueThreshold)]]" models="[[parsedModelNames]]">
+                                  <div class="flex">
+                                    <div class="conf-text">Mean attributions</div>
+                                    <paper-icon-button
+                                      icon="info-outline"
+                                      class="info-icon threshold-info-icon no-padding"
+                                      on-tap="openDialog"
+                                    >
+                                    </paper-icon-button>
+                                    <paper-dialog
+                                      class="dialog-text"
+                                      horizontal-align="auto"
+                                      vertical-align="auto"
+                                    >
+                                      <div class="dialog-title">
+                                        Mean attributions
+                                      </div>
+                                      <div>
+                                        This table shows the average attribution value for each feature across a set of datapoints, ordered from maximum to minimum.
+                                      </div>
+                                    </paper-dialog>
+                                  </div>
+                                  <wit-attribution-table
+                                    attributions="[[getFacetedAttributions(facetedMeanAttributions_, featureValueThreshold)]]"
+                                    models="[[parsedModelNames]]"
+                                    colors="[[attributionColorScale]]">
                                   </wit-attribution-table>
                                 </div>
                               </template>
@@ -3021,8 +3053,31 @@ limitations under the License.
                               if="[[hasAttributions_(attributions)]]"
                             >
                               <div class="perf-holder">
-                                <div class="conf-text">Mean attributions</div>
-                                <wit-attribution-table attributions="[[meanAttributions_]]" models="[[parsedModelNames]]">
+                                <div class="flex">
+                                  <div class="conf-text">Mean attributions</div>
+                                  <paper-icon-button
+                                    icon="info-outline"
+                                    class="info-icon threshold-info-icon no-padding"
+                                    on-tap="openDialog"
+                                  >
+                                  </paper-icon-button>
+                                  <paper-dialog
+                                    class="dialog-text"
+                                    horizontal-align="auto"
+                                    vertical-align="auto"
+                                  >
+                                    <div class="dialog-title">
+                                      Mean attributions
+                                    </div>
+                                    <div>
+                                        This table shows the average attribution value for each feature across a set of datapoints, ordered from maximum to minimum.
+                                    </div>
+                                  </paper-dialog>
+                                </div>
+                                <wit-attribution-table
+                                  attributions="[[meanAttributions_]]"
+                                  models="[[parsedModelNames]]"
+                                  colors="[[attributionColorScale]]">
                                 </wit-attribution-table>
                               </div>
                             </template>
@@ -3314,8 +3369,31 @@ limitations under the License.
                           >
                             <div class="perfs-holder">
                               <div class="perf-holder">
-                                <div class="conf-text">Mean attributions</div>
-                                <wit-attribution-table attributions="[[getFacetedAttributions(facetedMeanAttributions_, featureValueThreshold)]]" models="[[parsedModelNames]]">
+                                <div class="flex">
+                                  <div class="conf-text">Mean attributions</div>
+                                  <paper-icon-button
+                                    icon="info-outline"
+                                    class="info-icon threshold-info-icon no-padding"
+                                    on-tap="openDialog"
+                                  >
+                                  </paper-icon-button>
+                                  <paper-dialog
+                                    class="dialog-text"
+                                    horizontal-align="auto"
+                                    vertical-align="auto"
+                                  >
+                                    <div class="dialog-title">
+                                      Mean attributions
+                                    </div>
+                                    <div>
+                                        This table shows the average attribution value for each feature across a set of datapoints, ordered from maximum to minimum.
+                                    </div>
+                                  </paper-dialog>
+                                </div>
+                                <wit-attribution-table
+                                  attributions="[[getFacetedAttributions(facetedMeanAttributions_, featureValueThreshold)]]"
+                                  models="[[parsedModelNames]]"
+                                  colors="[[attributionColorScale]]">
                                 </wit-attribution-table>
                               </div>
                             </div>
@@ -3492,8 +3570,31 @@ limitations under the License.
                         >
                           <div class="perfs-holder">
                             <div class="perf-holder">
-                              <div class="conf-text">Mean attributions</div>
-                              <wit-attribution-table attributions="[[meanAttributions_]]" models="[[parsedModelNames]]">
+                              <div class="flex">
+                                <div class="conf-text">Mean attributions</div>
+                                <paper-icon-button
+                                  icon="info-outline"
+                                  class="info-icon threshold-info-icon no-padding"
+                                  on-tap="openDialog"
+                                >
+                                </paper-icon-button>
+                                <paper-dialog
+                                  class="dialog-text"
+                                  horizontal-align="auto"
+                                  vertical-align="auto"
+                                >
+                                  <div class="dialog-title">
+                                    Mean attributions
+                                  </div>
+                                  <div>
+                                    This table shows the average attribution value for each feature across a set of datapoints, ordered from maximum to minimum.
+                                  </div>
+                                </paper-dialog>
+                              </div>
+                              <wit-attribution-table
+                                attributions="[[meanAttributions_]]"
+                                models="[[parsedModelNames]]"
+                                colors="[[attributionColorScale]]">
                               </wit-attribution-table>
                             </div>
                           </div>
@@ -3565,8 +3666,8 @@ limitations under the License.
                   </div>
                   <div class="perf-table-entries-holder">
                     <template is="dom-repeat" items="[[regressionEntries_]]">
-                      <div class="perf-table-entry">
-                        <div class="perf-table-row">
+                      <div class="regression-perf-table-entry">
+                        <div class="regression-perf-table-row">
                           <div class="perf-table-arrow"></div>
                           <div class="perf-table-val perf-table-text-entry">
                             [[item.name]]
@@ -3608,9 +3709,32 @@ limitations under the License.
                           </div>
                         </div>
                         <template is="dom-if" if="[[hasAttributions_(attributions)]]">
-                          <div class="perf-holder regression-attr-holder">
-                            <div class="conf-text">Mean attributions</div>
-                            <wit-attribution-table attributions="[[getRegressionAttributions(item.name)]]" models="[[parsedModelNames]]">
+                          <div class="regression-attr-holder">
+                            <div class="flex">
+                              <div class="conf-text">Mean attributions</div>
+                              <paper-icon-button
+                                icon="info-outline"
+                                class="info-icon threshold-info-icon no-padding"
+                                on-tap="openDialog"
+                              >
+                              </paper-icon-button>
+                              <paper-dialog
+                                class="dialog-text"
+                                horizontal-align="auto"
+                                vertical-align="auto"
+                              >
+                                <div class="dialog-title">
+                                  Mean attributions
+                                </div>
+                                <div>
+                                  This table shows the average attribution value for each feature across a set of datapoints, ordered from maximum to minimum.
+                                </div>
+                              </paper-dialog>
+                            </div>
+                            <wit-attribution-table
+                              attributions="[[getRegressionAttributions(item.name)]]"
+                              models="[[parsedModelNames]]"
+                              colors="[[attributionColorScale]]">
                             </wit-attribution-table>
                           </div>
                         </template>

--- a/wit_dashboard/wit-example-viewer.ts
+++ b/wit_dashboard/wit-example-viewer.ts
@@ -85,7 +85,6 @@ namespace wit_example_viewer {
   const CHANGE_CALLBACK_TIMER_DELAY_MS = 1000;
   const noAttributionColor = '#fff';
   const defaultTextColor = '#3c4043';
-  const lightTextColor = '#fff';
 
   // Regex to find bytes features that are encoded images. Follows the guide at
   // go/tf-example.
@@ -183,6 +182,7 @@ namespace wit_example_viewer {
       compareMode: Boolean,
       compareImageInfo: {type: Object, value: {}},
       compareTitle: String,
+      textColorFunction: Object,
     },
     observers: [
       'displaySaliency(saliency, example)',
@@ -461,19 +461,6 @@ namespace wit_example_viewer {
       requestAnimationFrame(() => this._haveSaliencyImpl());
     },
 
-    // Determines if text should be light or dark due to the saliency-generated
-    // background of the text box.
-    _useLightColor(saliency) {
-      const percentile = (saliency - this.minSal) / (this.maxSal - this.minSal);
-      if (this.minSal < 0 && this.maxSal > 0) {
-        return percentile < 0.3 || percentile > 0.7;
-      } else if (this.minSal < 0) {
-        return percentile < 0.6;
-      } else {
-        return percentile > 0.4;
-      }
-    },
-
     _haveSaliencyImpl: function() {
       // TODO(jameswex): Color counterfactual column if using attribution-based
       // counterfactuals.
@@ -519,7 +506,7 @@ namespace wit_example_viewer {
           )
           .style('color', (d: {}, i: number) => {
             const num = Array.isArray(val) ? val[i] : val;
-            return this._useLightColor(num) ? lightTextColor : defaultTextColor;
+            return this.textColorFunction(num, this.minSal, this.maxSal);
           });
 
         // Color the "more feature values" button with the most extreme saliency


### PR DESCRIPTION
Updates all per discussions with Mahima for UX:
- Use existing attributions color scale in global attributions table
- Left-align all performance indicators in performance table, instead of center-align
- Add info button/popup to global attributions table
- Remove gutter from expanded performance row in table
- Some border/spacing fixes in performance tables
- Styling global attributions table per feedback

For issue #81 