### PR TITLE
Performance tab: Add AUC for precision-recall charts

### DIFF
--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -2767,7 +2767,7 @@ limitations under the License.
                                 </div>
                                 <div class="perf-holder">
                                   <div class="perf-curve-text">
-                                    PR curve (AUC: [[getPrCurveAucForSlice(aucs_, index)]])
+                                    [[getPrCurveAucForSlice(aucs_, index)]]
                                     <paper-icon-button
                                       icon="info-outline"
                                       class="info-icon threshold-info-icon no-padding"
@@ -2971,7 +2971,7 @@ limitations under the License.
                               </div>
                               <div class="perf-holder">
                                 <div class="perf-curve-text">
-                                  PR curve (AUC: [[getPrCurveAucOverall(aucs_)]])
+                                  [[getPrCurveAucOverall(aucs_)]]
                                   <paper-icon-button
                                     icon="info-outline"
                                     class="info-icon threshold-info-icon no-padding"
@@ -3263,7 +3263,7 @@ limitations under the License.
                                 </div>
                                 <div class="perf-holder">
                                   <div class="perf-curve-text">
-                                    PR curve for [[getLabel(labelInd)]] (AUC: [[getPrCurveAucForLabel(aucs_, labelInd, index)]])
+                                    [[getPrCurveAucForLabel(aucs_, labelInd, index)]]
                                     <paper-icon-button
                                       icon="info-outline"
                                       class="info-icon threshold-info-icon no-padding"
@@ -3446,7 +3446,7 @@ limitations under the License.
                               </div>
                               <div class="perf-holder">
                                 <div class="perf-curve-text">
-                                  PR curve for [[getLabel(labelInd)]] (AUC: [[getPrCurveAucForLabel(aucs_, labelInd, '')]])
+                                  [[getPrCurveAucForLabel(aucs_, labelInd, '')]]
                                   <paper-icon-button
                                     icon="info-outline"
                                     class="info-icon threshold-info-icon no-padding"
@@ -5699,7 +5699,7 @@ limitations under the License.
           const yAxis = isRoc ? 'TPR' : 'PPV';
           const xAxisLabel = isRoc ? 'FPR' : 'Recall';
           const yAxisLabel = isRoc ? 'TPR' : 'Precision';
-          const projectionsInChartSpace = []; // collected for AUC calculation
+          const projectionsForModels = []; // collected for AUC calculation
           for (let modelInd = 0; modelInd < thresholdStats.length; modelInd++) {
             let currentThresholdData = null;
             const data = thresholdStats[modelInd].thresholds
@@ -5723,7 +5723,7 @@ limitations under the License.
 
               // AUC is only calculated for plots of PR curves
               if (!isRoc) {
-                projectionsInChartSpace.push(data);
+                projectionsForModels.push(data);
               }
             chart.setSeriesData(
               this.strWithModelName_('Threshold set', modelInd),
@@ -5788,18 +5788,27 @@ limitations under the License.
           }
 
           // Update AUC for PR curves
-          // This assigns the property as a whole so Polymer notices
-          // and updates the DOM (which is why it's copying existing values).
-          if (!isRoc && projectionsInChartSpace.length > 0) {
-            const updatedAucs = {};
-            Object.keys(this.aucs_ || {}).forEach(chartId => {
-              updatedAucs[chartId] = this.aucs_[chartId];
-            });
-            projectionsInChartSpace.forEach(projectionInChartSpace => {
-              updatedAucs[chart.id] = this.calculateAreaUnderCurve(projectionInChartSpace);
-            });
-            this.aucs_ = updatedAucs;
+          if (!isRoc && projectionsForModels.length > 0) {
+            this.updateAucs_(chart.id, projectionsForModels);
           }
+        },
+
+        /*
+         * Sets updated value for `this.aucs_``
+         * This assigns the property as a whole so Polymer notices
+         * and updates the DOM (which is why it's copying existing values).
+         */
+        updateAucs_(chartId, projectionsForModels) {
+          const updatedAucs = {};
+          Object.keys(this.aucs_ || {}).forEach(aucKey => {
+            updatedAucs[aucKey] = this.aucs_[aucKey];
+          });
+          projectionsForModels.forEach((projectionsForModel, modelIndex) => {
+            const aucKey = [chartId, modelIndex].join(':');
+            updatedAucs[aucKey] = this.calculateAreaUnderCurve(projectionsForModel);
+          });
+          this.aucs_ = updatedAucs;
+          return;
         },
 
         /**
@@ -5822,26 +5831,52 @@ limitations under the License.
         },
 
         getPrCurveAucOverall: function(aucs_) {
-          return this.formattedAucTextFor_('prchart');
+          const aucText =  this.formattedPrChartTitleWithAuc_('prchart');
+          return `PR curve${aucText}`;
         },
 
         getPrCurveAucForSlice: function(aucs_, index) {
           const chartId = this.getPrChartId(index);
-          return this.formattedAucTextFor_(chartId);
+          const aucText =  this.formattedPrChartTitleWithAuc_(chartId);
+          return `PR curve${aucText}`;
         },
 
         getPrCurveAucForLabel(aucs_, labelIndex, sliceIndexOrEmpty) {
           const chartId = this.getPrChartLabelId(labelIndex, sliceIndexOrEmpty);
-          return this.formattedAucTextFor_(chartId);
+          const aucText = this.formattedAucTextFor_(chartId);
+          const label = this.getLabel(labelIndex);
+          return `PR curve for ${label}${aucText}`;
         },
 
         /* Reads precomputed value and formats it for the UI.
-         * AUC values are computed in `plotChart`.
+         * AUC values are computed in `plotChart`, and the string building
+         * complexity here is for when a chart has more than one series
+         * (eg, when comparing models), and so more than one AUC value.
          */
-        formattedAucTextFor_(chartId) {
-          if (!this.aucs_) return;
+        formattedPrChartTitleWithAuc_(chartId) {
+          if (!this.aucs_ || this.numModels === 0) {
+            return '';
+          }
 
-          const aucValue = this.aucs_[chartId];
+          if (this.numModels === 1) {
+            let valueText = this.formattedAucForModel_(chartId, 0);
+            return ` (AUC: ${valueText})`;
+          }
+
+          // multiple models in the title
+          // example: `PR Curve (AUCs, 1: 0.82, 2: 0.64)`
+          let pieces = [];
+          for (let modelInd = 0; modelInd < this.numModels; modelInd++) {
+            let valueText = this.formattedAucForModel_(chartId, modelInd);
+            let modelName = this.getModelName_(modelInd);
+            pieces.push(`${modelName}: ${valueText}`);
+          }
+          return ` (AUCs, ${pieces.join(', ')})`;
+        },
+
+        formattedAucForModel_(chartId, modelIndex) {
+          const aucKey = [chartId, modelIndex].join(':');
+          const aucValue = this.aucs_[aucKey];
           return (aucValue && aucValue.toFixed)
             ? aucValue.toFixed(2)
             : 0;

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -3224,6 +3224,7 @@ limitations under the License.
                                         <i>binarized</i> versions of the
                                         problem).
                                       </div>
+                                      <div>[[describeRocAuc()]]</div>
                                     </paper-dialog>
                                   </div>
                                   <div class="perf-curve-x-label">
@@ -3885,7 +3886,7 @@ limitations under the License.
             type: Array,
             value: () => [],
           },
-          // Calculated states for AUC for PR curve charts, keyed by chartId
+          // Calculated states of AUC for ROC and PR curve charts, keyed by (chartId, modelIndex)
           aucs_: {
             type: Object,
             value: () => {}
@@ -5786,7 +5787,7 @@ limitations under the License.
             let width = (chartXys[i].step - last.step);
             let height = (chartXys[i].scalar - last.scalar);
             let rect = (width * Math.min(chartXys[i].scalar, last.scalar))
-            let triangle = (width * height)/2;
+            let triangle = (width * height) / 2;
 
             auc += (rect + triangle);
             last = chartXys[i];
@@ -5857,19 +5858,35 @@ limitations under the License.
         },
 
         describeRocChart() {
-          return 'A receiver operating characteristic (ROC) curve plots the true positive rate (TPR) against the false positive rate (FPR) at various classification thresholds.';
+          return `
+            A receiver operating characteristic (ROC) curve plots the true
+            positive rate (TPR) against the false positive rate (FPR) at
+            various classification thresholds.
+          `;
         },
 
         describeRocAuc() {
-          return 'Area under the curve (AUC) summarizes model performance across all thresholds, and ROC-AUC represents the probability that a random positive example will have a higher score than a random negative example.';
+          return `
+            Area under the curve (AUC) summarizes model performance across
+            all thresholds, and ROC-AUC represents the probability that a
+            random positive example will have a higher score than a random
+            negative example.
+          `;
         },
 
         describePrChart() {
-          return 'A precision-recall (PR) curve plots precision against recall at various classification thresholds.';
+          return `
+            A precision-recall (PR) curve plots precision against recall at
+            various classification thresholds.
+          `;
         },
 
         describePrAuc() {
-          return 'Area under the curve (AUC) summarizes performance across all thresholds, and PR-AUC typically corresponds to the average precision.';
+          return `
+            Area under the curve (AUC) summarizes performance across all
+            thresholds, and PR-AUC typically corresponds to the average
+            precision.
+          `;
         },
 
         /**

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -2731,7 +2731,7 @@ limitations under the License.
                               >
                                 <div class="perf-holder">
                                   <div class="perf-curve-text">
-                                    ROC curve
+                                    [[getRocChartTitleForSlice(aucs_, index)]]
                                     <paper-icon-button
                                       icon="info-outline"
                                       class="info-icon threshold-info-icon no-padding"
@@ -2744,12 +2744,8 @@ limitations under the License.
                                       vertical-align="bottom"
                                     >
                                       <div class="dialog-title">ROC curve</div>
-                                      <div>
-                                        A receiver operating characteristic (ROC)
-                                        curve plots the true positive rate (TPR)
-                                        against the false positive rate (FPR) at
-                                        various classification thresholds.
-                                      </div>
+                                      <div>[[describeRocChart()]]</div>
+                                      <div>[[describeRocAuc()]]</div>
                                     </paper-dialog>
                                   </div>
                                   <div class="perf-curve-x-label">
@@ -2767,7 +2763,7 @@ limitations under the License.
                                 </div>
                                 <div class="perf-holder">
                                   <div class="perf-curve-text">
-                                    [[getPrCurveAucForSlice(aucs_, index)]]
+                                    [[getPrChartTitleForSlice(aucs_, index)]]
                                     <paper-icon-button
                                       icon="info-outline"
                                       class="info-icon threshold-info-icon no-padding"
@@ -2780,11 +2776,8 @@ limitations under the License.
                                       vertical-align="bottom"
                                     >
                                       <div class="dialog-title">PR curve</div>
-                                      <div>
-                                        A precision-recall (PR) curve plots
-                                        precision against recall at various
-                                        classification thresholds.
-                                      </div>
+                                      <div>[[describePrChart()]]</div>
+                                      <div>[[describePrAuc()]]</div>
                                     </paper-dialog>
                                   </div>
                                   <div class="perf-curve-x-label">Recall</div>
@@ -2935,7 +2928,7 @@ limitations under the License.
                             >
                               <div class="perf-holder">
                                 <div class="perf-curve-text">
-                                  ROC curve
+                                  [[getRocChartTitleOverall(aucs_)]]
                                   <paper-icon-button
                                     icon="info-outline"
                                     class="info-icon threshold-info-icon no-padding"
@@ -2948,12 +2941,8 @@ limitations under the License.
                                     vertical-align="bottom"
                                   >
                                     <div class="dialog-title">ROC curve</div>
-                                    <div>
-                                      A receiver operating characteristic (ROC)
-                                      curve plots the true positive rate (TPR)
-                                      against the false positive rate (FPR) at
-                                      various classification thresholds.
-                                    </div>
+                                    <div>[[describeRocChart()]]</div>
+                                    <div>[[describeRocAuc()]]</div>
                                   </paper-dialog>
                                 </div>
                                 <div class="perf-curve-x-label">
@@ -2971,7 +2960,7 @@ limitations under the License.
                               </div>
                               <div class="perf-holder">
                                 <div class="perf-curve-text">
-                                  [[getPrCurveAucOverall(aucs_)]]
+                                  [[getPrChartTitleOverall(aucs_)]]
                                   <paper-icon-button
                                     icon="info-outline"
                                     class="info-icon threshold-info-icon no-padding"
@@ -2984,11 +2973,8 @@ limitations under the License.
                                     vertical-align="bottom"
                                   >
                                     <div class="dialog-title">PR curve</div>
-                                    <div>
-                                      A precision-recall (PR) curve plots
-                                      precision against recall at various
-                                      classification thresholds.
-                                    </div>
+                                    <div>[[describePrChart()]]</div>
+                                    <div>[[describePrAuc()]]</div>
                                   </paper-dialog>
                                 </div>
                                 <div class="perf-curve-x-label">Recall</div>
@@ -3213,7 +3199,7 @@ limitations under the License.
                               <div class="perfs-holder">
                                 <div class="perf-holder">
                                   <div class="perf-curve-text">
-                                    ROC curve for [[getLabel(labelInd)]]
+                                    [[getRocChartTitleForLabel(aucs_, labelInd, index)]]
                                     <paper-icon-button
                                       icon="info-outline"
                                       class="info-icon threshold-info-icon no-padding"
@@ -3225,16 +3211,8 @@ limitations under the License.
                                       horizontal-align="right"
                                       vertical-align="bottom"
                                     >
-                                      <div class="dialog-title">
-                                        ROC curve
-                                      </div>
-                                      <div>
-                                        A receiver operating characteristic
-                                        (ROC) curve plots the true positive rate
-                                        (TPR) against the false positive rate
-                                        (FPR) at various classification
-                                        thresholds.
-                                      </div>
+                                      <div class="dialog-title">ROC curve</div>
+                                      <div>[[describeRocChart()]]</div>
                                       <div>
                                         For this multi-class classification
                                         problem, we plot one ROC curve for each
@@ -3263,7 +3241,7 @@ limitations under the License.
                                 </div>
                                 <div class="perf-holder">
                                   <div class="perf-curve-text">
-                                    [[getPrCurveAucForLabel(aucs_, labelInd, index)]]
+                                    [[getPrChartTitleForLabel(aucs_, labelInd, index)]]
                                     <paper-icon-button
                                       icon="info-outline"
                                       class="info-icon threshold-info-icon no-padding"
@@ -3276,11 +3254,7 @@ limitations under the License.
                                       vertical-align="bottom"
                                     >
                                       <div class="dialog-title">PR curve</div>
-                                      <div>
-                                        A precision-recall (PR) curve plots
-                                        precision against recall at various
-                                        classification thresholds.
-                                      </div>
+                                      <div>[[describePrChart()]]</div>
                                       <div>
                                         For this multi-class classification
                                         problem, we plot one PR curve for each
@@ -3292,6 +3266,7 @@ limitations under the License.
                                         <i>binarized</i> versions of the
                                         problem).
                                       </div>
+                                      <div>[[describePrAuc()]]</div>
                                     </paper-dialog>
                                   </div>
                                   <div class="perf-curve-x-label">Recall</div>
@@ -3402,7 +3377,7 @@ limitations under the License.
                             <div class="perfs-holder">
                               <div class="perf-holder">
                                 <div class="perf-curve-text">
-                                  ROC curve for [[getLabel(labelInd)]]
+                                  [[getRocChartTitleForLabel(aucs_, labelInd, '')]]
                                   <paper-icon-button
                                     icon="info-outline"
                                     class="info-icon threshold-info-icon no-padding"
@@ -3415,12 +3390,7 @@ limitations under the License.
                                     vertical-align="bottom"
                                   >
                                     <div class="dialog-title">ROC curve</div>
-                                    <div>
-                                      A receiver operating characteristic (ROC)
-                                      curve plots the true positive rate (TPR)
-                                      against the false positive rate (FPR) at
-                                      various classification thresholds.
-                                    </div>
+                                    <div>[[describeRocChart()]]</div>
                                     <div>
                                       For this multi-class classification
                                       problem, we plot one ROC curve for each
@@ -3429,6 +3399,7 @@ limitations under the License.
                                       the others as negatives (<i>i.e.</i>
                                       <i>binarized</i> versions of the problem).
                                     </div>
+                                    <div>[[describeRocAuc()]]</div>
                                   </paper-dialog>
                                 </div>
                                 <div class="perf-curve-x-label">
@@ -3446,7 +3417,7 @@ limitations under the License.
                               </div>
                               <div class="perf-holder">
                                 <div class="perf-curve-text">
-                                  [[getPrCurveAucForLabel(aucs_, labelInd, '')]]
+                                  [[getPrChartTitleForLabel(aucs_, labelInd, '')]]
                                   <paper-icon-button
                                     icon="info-outline"
                                     class="info-icon threshold-info-icon no-padding"
@@ -3459,11 +3430,7 @@ limitations under the License.
                                     vertical-align="bottom"
                                   >
                                     <div class="dialog-title">PR curve</div>
-                                    <div>
-                                      A precision-recall (PR) curve plots
-                                      precision against recall at various
-                                      classification thresholds.
-                                    </div>
+                                    <div>[[describePrChart()]]</div>
                                     <div>
                                       For this multi-class classification
                                       problem, we plot one PR curve for each
@@ -3472,6 +3439,7 @@ limitations under the License.
                                       the others as negatives (<i>i.e.</i>
                                       <i>binarized</i> versions of the problem).
                                     </div>
+                                    <div>[[describePrAuc()]]</div>
                                   </paper-dialog>
                                 </div>
                                 <div class="perf-curve-x-label">Recall</div>
@@ -5720,11 +5688,7 @@ limitations under the License.
                 };
               })
               .reverse();
-
-              // AUC is only calculated for plots of PR curves
-              if (!isRoc) {
-                projectionsForModels.push(data);
-              }
+            projectionsForModels.push(data);
             chart.setSeriesData(
               this.strWithModelName_('Threshold set', modelInd),
               [currentThresholdData]
@@ -5787,8 +5751,8 @@ limitations under the License.
             chart.setVisibleSeries(visibleCharts);
           }
 
-          // Update AUC for PR curves
-          if (!isRoc && projectionsForModels.length > 0) {
+          // Update AUC values
+          if (projectionsForModels.length > 0) {
             this.updateAucs_(chart.id, projectionsForModels);
           }
         },
@@ -5830,22 +5794,34 @@ limitations under the License.
           return auc;
         },
 
-        getPrCurveAucOverall: function(aucs_) {
-          const aucText =  this.formattedPrChartTitleWithAuc_('prchart');
-          return `PR curve${aucText}`;
+        getRocChartTitleOverall: function(aucs_) {
+          return this.formattedChartTitleWithAucs_('ROC curve', 'rocchart');
         },
 
-        getPrCurveAucForSlice: function(aucs_, index) {
-          const chartId = this.getPrChartId(index);
-          const aucText =  this.formattedPrChartTitleWithAuc_(chartId);
-          return `PR curve${aucText}`;
+        getRocChartTitleForSlice: function(aucs_, index) {
+          const chartId = this.getRocChartId(index);
+          return this.formattedChartTitleWithAucs_('ROC curve', chartId);
         },
 
-        getPrCurveAucForLabel(aucs_, labelIndex, sliceIndexOrEmpty) {
-          const chartId = this.getPrChartLabelId(labelIndex, sliceIndexOrEmpty);
-          const aucText = this.formattedAucTextFor_(chartId);
+        getRocChartTitleForLabel: function(aucs_, labelIndex, sliceIndexOrEmpty) {
+          const chartId = this.getRocChartLabelId(labelIndex, sliceIndexOrEmpty);
           const label = this.getLabel(labelIndex);
-          return `PR curve for ${label}${aucText}`;
+          return this.formattedChartTitleWithAucs_(`ROC curve for ${label}`, chartId);
+        },
+
+        getPrChartTitleOverall: function(aucs_) {
+          return this.formattedChartTitleWithAucs_('PR curve', 'prchart');
+        },
+
+        getPrChartTitleForSlice: function(aucs_, index) {
+          const chartId = this.getPrChartId(index);
+          return this.formattedChartTitleWithAucs_('PR curve', chartId);
+        },
+
+        getPrChartTitleForLabel(aucs_, labelIndex, sliceIndexOrEmpty) {
+          const chartId = this.getPrChartLabelId(labelIndex, sliceIndexOrEmpty);
+          const label = this.getLabel(labelIndex);
+          return this.formattedChartTitleWithAucs_(`PR curve for ${label}`, chartId);
         },
 
         /* Reads precomputed value and formats it for the UI.
@@ -5853,25 +5829,23 @@ limitations under the License.
          * complexity here is for when a chart has more than one series
          * (eg, when comparing models), and so more than one AUC value.
          */
-        formattedPrChartTitleWithAuc_(chartId) {
+        formattedChartTitleWithAucs_(title, chartId) {
           if (!this.aucs_ || this.numModels === 0) {
-            return '';
+            return title;
           }
 
           if (this.numModels === 1) {
             let valueText = this.formattedAucForModel_(chartId, 0);
-            return ` (AUC: ${valueText})`;
+            return `${title} (AUC: ${valueText})`;
           }
 
           // multiple models in the title
-          // example: `PR Curve (AUCs, 1: 0.82, 2: 0.64)`
-          let pieces = [];
+          // example: `PR Curve (AUCs: 0.82, 0.64)`
+          let valueTexts = [];
           for (let modelInd = 0; modelInd < this.numModels; modelInd++) {
-            let valueText = this.formattedAucForModel_(chartId, modelInd);
-            let modelName = this.getModelName_(modelInd);
-            pieces.push(`${modelName}: ${valueText}`);
+            valueTexts.push(this.formattedAucForModel_(chartId, modelInd));
           }
-          return ` (AUCs, ${pieces.join(', ')})`;
+          return `${title} (AUCs: ${valueTexts.join(', ')})`;
         },
 
         formattedAucForModel_(chartId, modelIndex) {
@@ -5880,6 +5854,22 @@ limitations under the License.
           return (aucValue && aucValue.toFixed)
             ? aucValue.toFixed(2)
             : 0;
+        },
+
+        describeRocChart() {
+          return 'A receiver operating characteristic (ROC) curve plots the true positive rate (TPR) against the false positive rate (FPR) at various classification thresholds.';
+        },
+
+        describeRocAuc() {
+          return 'Area under the curve (AUC) summarizes model performance across all thresholds, and ROC-AUC represents the probability that a random positive example will have a higher score than a random negative example.';
+        },
+
+        describePrChart() {
+          return 'A precision-recall (PR) curve plots precision against recall at various classification thresholds.';
+        },
+
+        describePrAuc() {
+          return 'Area under the curve (AUC) summarizes performance across all thresholds, and PR-AUC typically corresponds to the average precision.';
         },
 
         /**

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -2767,7 +2767,7 @@ limitations under the License.
                                 </div>
                                 <div class="perf-holder">
                                   <div class="perf-curve-text">
-                                    PR curve
+                                    PR curve (AUC: [[getPrCurveAucForSlice(aucs_, index)]])
                                     <paper-icon-button
                                       icon="info-outline"
                                       class="info-icon threshold-info-icon no-padding"
@@ -2971,7 +2971,7 @@ limitations under the License.
                               </div>
                               <div class="perf-holder">
                                 <div class="perf-curve-text">
-                                  PR curve
+                                  PR curve (AUC: [[getPrCurveAucOverall(aucs_)]])
                                   <paper-icon-button
                                     icon="info-outline"
                                     class="info-icon threshold-info-icon no-padding"
@@ -3263,7 +3263,7 @@ limitations under the License.
                                 </div>
                                 <div class="perf-holder">
                                   <div class="perf-curve-text">
-                                    PR curve for [[getLabel(labelInd)]]
+                                    PR curve for [[getLabel(labelInd)]] (AUC: [[getPrCurveAucForLabel(aucs_, labelInd, index)]])
                                     <paper-icon-button
                                       icon="info-outline"
                                       class="info-icon threshold-info-icon no-padding"
@@ -3446,7 +3446,7 @@ limitations under the License.
                               </div>
                               <div class="perf-holder">
                                 <div class="perf-curve-text">
-                                  PR curve for [[getLabel(labelInd)]]
+                                  PR curve for [[getLabel(labelInd)]] (AUC: [[getPrCurveAucForLabel(aucs_, labelInd, '')]])
                                   <paper-icon-button
                                     icon="info-outline"
                                     class="info-icon threshold-info-icon no-padding"
@@ -3916,6 +3916,11 @@ limitations under the License.
           inferenceStats_: {
             type: Array,
             value: () => [],
+          },
+          // Calculated states for AUC for PR curve charts, keyed by chartId
+          aucs_: {
+            type: Object,
+            value: () => {}
           },
           // Array of feature values and their set classification thresholds, for
           // Polymer display purposes.
@@ -5694,6 +5699,7 @@ limitations under the License.
           const yAxis = isRoc ? 'TPR' : 'PPV';
           const xAxisLabel = isRoc ? 'FPR' : 'Recall';
           const yAxisLabel = isRoc ? 'TPR' : 'Precision';
+          const projectionsInChartSpace = []; // collected for AUC calculation
           for (let modelInd = 0; modelInd < thresholdStats.length; modelInd++) {
             let currentThresholdData = null;
             const data = thresholdStats[modelInd].thresholds
@@ -5714,6 +5720,11 @@ limitations under the License.
                 };
               })
               .reverse();
+
+              // AUC is only calculated for plots of PR curves
+              if (!isRoc) {
+                projectionsInChartSpace.push(data);
+              }
             chart.setSeriesData(
               this.strWithModelName_('Threshold set', modelInd),
               [currentThresholdData]
@@ -5775,6 +5786,65 @@ limitations under the License.
             chart.colorScale.domain(visibleCharts);
             chart.setVisibleSeries(visibleCharts);
           }
+
+          // Update AUC for PR curves
+          // This assigns the property as a whole so Polymer notices
+          // and updates the DOM (which is why it's copying existing values).
+          if (!isRoc && projectionsInChartSpace.length > 0) {
+            const updatedAucs = {};
+            Object.keys(this.aucs_ || {}).forEach(chartId => {
+              updatedAucs[chartId] = this.aucs_[chartId];
+            });
+            projectionsInChartSpace.forEach(projectionInChartSpace => {
+              updatedAucs[chart.id] = this.calculateAreaUnderCurve(projectionInChartSpace);
+            });
+            this.aucs_ = updatedAucs;
+          }
+        },
+
+        /**
+         * Takes a list of [{step, scalar, threshold}] at each discrete threshold value,
+         * and returns the area under the curve.
+         */
+        calculateAreaUnderCurve(chartXys) {
+          let auc = 0;
+          let last = chartXys[0];
+          for (let i = 1; i < chartXys.length; i++) {
+            let width = (chartXys[i].step - last.step);
+            let height = (chartXys[i].scalar - last.scalar);
+            let rect = (width * Math.min(chartXys[i].scalar, last.scalar))
+            let triangle = (width * height)/2;
+
+            auc += (rect + triangle);
+            last = chartXys[i];
+          }
+          return auc;
+        },
+
+        getPrCurveAucOverall: function(aucs_) {
+          return this.formattedAucTextFor_('prchart');
+        },
+
+        getPrCurveAucForSlice: function(aucs_, index) {
+          const chartId = this.getPrChartId(index);
+          return this.formattedAucTextFor_(chartId);
+        },
+
+        getPrCurveAucForLabel(aucs_, labelIndex, sliceIndexOrEmpty) {
+          const chartId = this.getPrChartLabelId(labelIndex, sliceIndexOrEmpty);
+          return this.formattedAucTextFor_(chartId);
+        },
+
+        /* Reads precomputed value and formats it for the UI.
+         * AUC values are computed in `plotChart`.
+         */
+        formattedAucTextFor_(chartId) {
+          if (!this.aucs_) return;
+
+          const aucValue = this.aucs_[chartId];
+          return (aucValue && aucValue.toFixed)
+            ? aucValue.toFixed(2)
+            : 0;
         },
 
         /**


### PR DESCRIPTION
This change adds AUCs for each series to the title of precision-recall charts (see https://github.com/PAIR-code/what-if-tool/issues/78), like these examples:

<div>
<img width="200" alt="chart" src="https://user-images.githubusercontent.com/1056957/81978060-f26ed800-95f8-11ea-99e9-f1e2a46fd719.png" />
<img width="200" alt="chart" src="https://user-images.githubusercontent.com/1056957/81978203-2cd87500-95f9-11ea-83a1-914b81febeb3.png" />
</div>

To do this, it adds a new property, `aucs_`.  When `plotChart` is called for a precision-recall chart, it computes the AUC and stores in `aucs_` keyed on `(chartId, modelIndex)`.  The charts in templates then call different methods to get the text for their titles.  Using the `[[getWhatever(foo, bar))]]` approach in the template works in practice to push changes back to the DOM, but only when setting the entire `this.aucs_` property at once.  I fiddled with `this.set('aucs_.${key}')` and `observers` and `{{bindings}}` but this approached seemed similar to what's used in other places and I it had the benefit of working :)  I did notice methods like `plotChart` get called repeatedly and this PR does add more work in there, but I assume that's fine.

I'm also assuming the quirks in the PR curve plots themselves are artifacts from the way precision and recall rates are projected into the chart space and interpolated (eg, charts often appear to have points at (0,0)).  This change doesn't impact how that already works, but the AUC values are computed from those same projections.

To test, I looked through the various demos and pasted some screenshots below.  I saw there was a test and lint task in `package.json` but they seemed leftover from tensorboard so I didn't try to run them.

### Smiling classification, sliced by subgroups for two features
![image](https://user-images.githubusercontent.com/1056957/81972367-7b354600-95f0-11ea-8a0b-631297dec3ab.png)

### Iris species by sepal length
Note the "zero" case.
![image](https://user-images.githubusercontent.com/1056957/81972240-517c1f00-95f0-11ea-91cf-2951001f0aa4.png)

### Comparing models for predicting income
This shoves a bit more into the title text :)  It would probably be nicer to move these into elements under the title per se, and color them to match, or alternate text might omit the model names to streamline: `AUCs: 0.35, 0.53`.

![image](https://user-images.githubusercontent.com/1056957/81972165-33162380-95f0-11ea-809a-2aa480e564ee.png)
![image](https://user-images.githubusercontent.com/1056957/81972184-3ad5c800-95f0-11ea-8895-825334a8ae88.png)


### Pre-trial detention
![image](https://user-images.githubusercontent.com/1056957/81972076-10840a80-95f0-11ea-85bb-636490a7eb38.png)

<img width="1142" alt="Screen Shot 2020-05-14 at 2 33 04 PM" src="https://user-images.githubusercontent.com/1056957/81972012-f5b19600-95ef-11ea-88ce-85a3d87b95ff.png">
