### PR TITLE
Add support for custom predict function in non-colab environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,8 +412,12 @@ def custom_predict_fn(examples, serving_bundle):
   # examples are a list of TFRecord objects, each object contains the features of each point.
   # serving_bundle is a dictionary that contains the data you will fill in the webpage,
   # such as server address, model name, model version, etc.
-  return classification_pb2.ClassificationResponse()
-  # ClassificationResponse contains the inference result for each example.
+  return []
+  # Return a "list" or a "list of list".
+  # For classification, a 2D list of numbers. The first dimension is for
+  # each example being predicted. The second dimension are the probabilities
+  # for each class ID in the prediction. For regression, a 1D list of numbers,
+  # with a regression score for each example being predicted.
 ```
 Check [here](https://github.com/PAIR-code/what-if-tool/pull/94#issuecomment-637535906) for a minimal example.
 

--- a/README.md
+++ b/README.md
@@ -404,22 +404,34 @@ Note that you may need to run `!sudo jupyter labextension ...` commands dependin
 Use of WIT after installation is the same as with the other notebook installations.
 
 ## Can I use my custom prediction without the Jupyter notebook or without the Colab notebook?
-Yes. You can do this by defining a python function with the following signature.
+Yes. You can do this by defining a python function with the following signature. Here is a minimal example:
 
 ```python
+import random
+NUM_POSSIBLE_CLASSES = 3
+
 # The function name "custom_predict_fn" must be exact.
 def custom_predict_fn(examples, serving_bundle):
   # examples are a list of TFRecord objects, each object contains the features of each point.
   # serving_bundle is a dictionary that contains the data you will fill in the webpage,
   # such as server address, model name, model version, etc.
-  return []
+
+  number_of_examples = len(examples)
+  results = []
+  for _ in range(number_of_examples):
+    scores = []
+    for clsid in range(NUM_POSSIBLE_CLASSES):
+      scores.append(random.random())
+    results.append(scores)  # classification
+    # results.append(result[0][0])  # this make a regression result
+  return results
+
   # Return a "list" or a "list of list".
   # For classification, a 2D list of numbers. The first dimension is for
   # each example being predicted. The second dimension are the probabilities
   # for each class ID in the prediction. For regression, a 1D list of numbers,
   # with a regression score for each example being predicted.
 ```
-Check [here](https://github.com/PAIR-code/what-if-tool/pull/94#issuecomment-637535906) for a minimal example.
 
 After you have implemented your function, assume the file name is `my_custom_predict_function.py`.
 Launch the TensorBoard server with `tensorboard --whatif-use-unsafe-custom-prediction my_custom_predict_function.py` 

--- a/README.md
+++ b/README.md
@@ -403,6 +403,26 @@ Note that you may need to run `!sudo jupyter labextension ...` commands dependin
 
 Use of WIT after installation is the same as with the other notebook installations.
 
+## Can I use my custom prediction without the Jupyter notebook or without the Colab notebook?
+Yes. You can do this by defining a python function with the following signature.
+
+```python
+# The function name "custom_predict_fn" must be exact.
+def custom_predict_fn(examples, serving_bundle):
+  # examples are a list of TFRecord objects, each object contains the features of each point.
+  # serving_bundle is a dictionary that contains the data you will fill in the webpage,
+  # such as server address, model name, model version, etc.
+  return classification_pb2.ClassificationResponse()
+  # ClassificationResponse contains the inference result for each example.
+```
+Check [here](https://github.com/PAIR-code/what-if-tool/pull/94#issuecomment-637535906) for a minimal example.
+
+After you have implemented your function, assume the file name is `my_custom_predict_function.py`.
+Launch the TensorBoard server with `tensorboard --whatif-use-unsafe-custom-prediction my_custom_predict_function.py` 
+and the function should be invoked once you have "Set up your data and model" in the what-if-tool page.
+The `unsafe` means that the function is not sandboxed, so make sure that 
+`my_custom_predict_function.py` won't accidently delete your experiment data.
+
 ## How can I help develop it?
 
 Check out the [developement guide](./DEVELOPMENT.md).

--- a/tensorboard_plugin_wit/wit_plugin.py
+++ b/tensorboard_plugin_wit/wit_plugin.py
@@ -43,6 +43,15 @@ from tensorboard.util import tb_logging
 
 logger = logging.getLogger('tensorboard')
 
+import sys
+sys.path.append(os.getcwd())
+custom_predict_fn = None
+try:
+  import custom_predict_fn
+  custom_predict_fn = custom_predict_fn.custom_predict_fn
+except Exception as e:
+  print(str(e))
+
 
 # Max number of examples to scan along the `examples_path` in order to return
 # statistics and sampling for features.
@@ -318,7 +327,8 @@ class WhatIfToolPlugin(base_plugin.TBPlugin):
             model_signatures[model_num],
             request.args.get('use_predict') == 'true',
             request.args.get('predict_input_tensor'),
-            request.args.get('predict_output_tensor'))
+            request.args.get('predict_output_tensor'),
+            custom_predict_fn=custom_predict_fn)
         (predictions, _) = inference_utils.run_inference_for_inference_results(
             examples_to_infer, serving_bundle)
         infer_objs.append(predictions)

--- a/tensorboard_plugin_wit/wit_plugin.py
+++ b/tensorboard_plugin_wit/wit_plugin.py
@@ -97,12 +97,9 @@ class WhatIfToolPlugin(base_plugin.TBPlugin):
         logger.info("custom_predict_fn loaded.")
 
       except Exception as e:
-        logger.info("Failed to load the custom predict function.")
-        logger.info(str(e))
-        # Show the error on the terminal.
-        print("Failed to load the custom predict function.")
-        print("Have you defined a function named custom_predict_fn?")
-        print(str(e))
+        logger.error(str(e))
+        logger.error("Failed to load the custom predict function.")
+        logger.error("Have you defined a function named custom_predict_fn?")
 
   def get_plugin_apps(self):
     """Obtains a mapping between routes and handlers. Stores the logdir.

--- a/tensorboard_plugin_wit/wit_plugin.py
+++ b/tensorboard_plugin_wit/wit_plugin.py
@@ -47,8 +47,8 @@ import sys
 sys.path.append(os.getcwd())
 custom_predict_fn = None
 try:
-  import custom_predict_fn
-  custom_predict_fn = custom_predict_fn.custom_predict_fn
+  import custom_wit_predict_fn
+  custom_predict_fn = custom_wit_predict_fn.custom_predict_fn
   logger.info("custom_predict_fn loaded.")
 except  ImportError as e:
   # No need to show error message. Most people don't use custom function.

--- a/tensorboard_plugin_wit/wit_plugin.py
+++ b/tensorboard_plugin_wit/wit_plugin.py
@@ -39,7 +39,6 @@ from tensorboard.plugins import base_plugin
 from utils import common_utils
 from utils import inference_utils
 from utils import platform_utils
-from tensorboard.util import tb_logging
 
 logger = logging.getLogger('tensorboard')
 

--- a/tensorboard_plugin_wit/wit_plugin.py
+++ b/tensorboard_plugin_wit/wit_plugin.py
@@ -441,7 +441,8 @@ class WhatIfToolPlugin(base_plugin.TBPlugin):
           request.args.get('predict_input_tensor'),
           request.args.get('predict_output_tensor'),
           request.args.get('x_min'), request.args.get('x_max'),
-          request.args.get('feature_index_pattern'))
+          request.args.get('feature_index_pattern'),
+          custom_predict_fn=self.custom_predict_fn)
       return http_util.Respond(request, json_mapping, 'application/json')
     except common_utils.InvalidUserInputError as e:
       return http_util.Respond(request, {'error': e.message},
@@ -450,7 +451,7 @@ class WhatIfToolPlugin(base_plugin.TBPlugin):
   def _infer_mutants_impl(self, feature_name, example_index, inference_addresses,
       model_names, model_type, model_versions, model_signatures, use_predict,
       predict_input_tensor, predict_output_tensor, x_min, x_max,
-      feature_index_pattern):
+      feature_index_pattern, custom_predict_fn):
     """Helper for generating PD plots for a feature."""
     examples = (self.examples if example_index == -1
                 else [self.examples[example_index]])
@@ -464,7 +465,8 @@ class WhatIfToolPlugin(base_plugin.TBPlugin):
           model_signatures[model_num],
           use_predict,
           predict_input_tensor,
-          predict_output_tensor))
+          predict_output_tensor,
+          custom_predict_fn=custom_predict_fn))
 
     viz_params = inference_utils.VizParams(
         x_min, x_max,

--- a/tensorboard_plugin_wit/wit_plugin.py
+++ b/tensorboard_plugin_wit/wit_plugin.py
@@ -44,7 +44,6 @@ from tensorboard.util import tb_logging
 logger = logging.getLogger('tensorboard')
 
 
-
 # Max number of examples to scan along the `examples_path` in order to return
 # statistics and sampling for features.
 NUM_EXAMPLES_TO_SCAN = 50
@@ -102,6 +101,7 @@ class WhatIfToolPlugin(base_plugin.TBPlugin):
         logger.info(str(e))
         # Show the error on the terminal.
         print("Failed to load the custom predict function.")
+        print("Have you defined a function named custom_predict_fn?")
         print(str(e))
 
   def get_plugin_apps(self):

--- a/tensorboard_plugin_wit/wit_plugin.py
+++ b/tensorboard_plugin_wit/wit_plugin.py
@@ -49,8 +49,10 @@ custom_predict_fn = None
 try:
   import custom_predict_fn
   custom_predict_fn = custom_predict_fn.custom_predict_fn
-except Exception as e:
-  print(str(e))
+  logger.info("custom_predict_fn loaded.")
+except  ImportError as e:
+  # No need to show error message. Most people don't use custom function.
+  pass
 
 
 # Max number of examples to scan along the `examples_path` in order to return

--- a/tensorboard_plugin_wit/wit_plugin_loader.py
+++ b/tensorboard_plugin_wit/wit_plugin_loader.py
@@ -60,12 +60,15 @@ class WhatIfToolPluginLoader(base_plugin.TBLoader):
         group = parser.add_argument_group('what-if-tool')
         try:
           group.add_argument(
-              '--wit-use-unsafe-custom-prediction',
+              '--whatif-use-unsafe-custom-prediction',
               dest='custom_predict_fn',
               metavar='YOUR_CUSTOM_PREDICT_FUNCTION.py',
               type=str,
               default='',
-              help="The file location of the custom prediction function"
+              help="The file location of your custom prediction function. Note \
+              that the flag executes arbitrary code, so make sure you passed the \
+              correct file location. See how to define the function in \
+              https://github.com/PAIR-code/what-if-tool/blob/master/README.md"
               )
         except argparse.ArgumentError:
           # This same flag is registered by TensorBoard's static profile

--- a/tensorboard_plugin_wit/wit_plugin_loader.py
+++ b/tensorboard_plugin_wit/wit_plugin_loader.py
@@ -55,3 +55,19 @@ class WhatIfToolPluginLoader(base_plugin.TBLoader):
         from tensorboard_plugin_wit.wit_plugin import WhatIfToolPlugin
 
         return WhatIfToolPlugin(context)
+
+    def define_flags(self, parser):
+        group = parser.add_argument_group('what-if-tool')
+        try:
+          group.add_argument(
+              '--wit-use-unsafe-custom-prediction',
+              dest='custom_predict_fn',
+              metavar='YOUR_CUSTOM_PREDICT_FUNCTION.py',
+              type=str,
+              default='',
+              help="The file location of the custom prediction function"
+              )
+        except argparse.ArgumentError:
+          # This same flag is registered by TensorBoard's static profile
+          # plugin, as long as it continues to be bundled. Nothing to do.
+            pass

--- a/utils/inference_utils.py
+++ b/utils/inference_utils.py
@@ -28,6 +28,7 @@ from google.protobuf import json_format
 from six import binary_type, string_types, integer_types
 from six import iteritems
 from six.moves import zip  # pylint: disable=redefined-builtin
+from inspect import signature
 
 from utils import common_utils
 from utils import platform_utils
@@ -846,7 +847,6 @@ def run_inference(examples, serving_bundle):
   elif serving_bundle.custom_predict_fn:
     # If custom_predict_fn is provided, pass examples directly for local
     # inference.
-    from inspect import signature
     sig = signature(serving_bundle.custom_predict_fn)
     params = sig.parameters
     # The custom_predict_fn for colab/jupyter accepts one parameter.

--- a/utils/inference_utils.py
+++ b/utils/inference_utils.py
@@ -844,6 +844,11 @@ def run_inference(examples, serving_bundle):
     return (common_utils.convert_prediction_values(values, serving_bundle),
             None)
   elif serving_bundle.custom_predict_fn:
+    try:
+      return (serving_bundle.custom_predict_fn(examples, serving_bundle), None)
+    except Exception as e:
+      print(str(e))
+      pass
     # If custom_predict_fn is provided, pass examples directly for local
     # inference.
     values = serving_bundle.custom_predict_fn(examples)

--- a/utils/inference_utils.py
+++ b/utils/inference_utils.py
@@ -868,10 +868,11 @@ def run_inference(examples, serving_bundle):
       try:
         return (serving_bundle.custom_predict_fn(examples, serving_bundle), None)
       except:
-        errormsg = ('Please make sure that there is custom_predict_fn.py '
+        errormsg = ('Please make sure that there is custom_wit_predict_fn.py '
                   'in where TensorBoard is launched. And a function named '
-                  'custom_predict_fn is defined in custom_predict_fn.py')
-        logger.error(errormsg)
+                  'custom_predict_fn is defined in that file. Also check if '
+                  'there is any error in the custom_predict_fn.')
+        raise RuntimeError(errormsg)
 
   else:
     return (platform_utils.call_servo(examples, serving_bundle), None)


### PR DESCRIPTION
This PR enables What-If-Tool to load the custom_predict_fn when running in a local TensorBoard server. The modification tries to load a python function `custom_predict_fn` from a file named `custom_wit_predict_fn.py` in TensorBoard's launching folder. If the function exists, the inference request will be redirected to that function. 

Tested locally with a compiled python wheel file along with the demo code in
https://github.com/pytorch/serve/pull/418