### PR TITLE
Bump tensorflow requirement from 1.12.0 to 1.12.1

### DIFF
--- a/witwidget/pip_package/setup.py
+++ b/witwidget/pip_package/setup.py
@@ -30,14 +30,14 @@ if '--project_name' in sys.argv:
   sys.argv.pop(project_name_idx)
 
 _TF_REQ = [
-    'tensorflow>=1.12.0',
+    'tensorflow>=1.12.1',
 ]
 
 # GPU build (note: the only difference is we depend on tensorflow-gpu
 # so pip doesn't overwrite it with the CPU build)
 if 'witwidget-gpu' in project_name:
   _TF_REQ = [
-      'tensorflow-gpu>=1.12.0',
+      'tensorflow-gpu>=1.12.1',
   ]
 
 REQUIRED_PACKAGES = [


### PR DESCRIPTION
tf.get_logger() is exposed starting from 1.12.1. 

If you use WitWidget with tensorflow 1.12.0 you get the following error:

```
  witwidget\notebook\base.py in __init__(self, config_builder)
        50       config_builder: WitConfigBuilder object containing settings for WIT.
        51     """
        52     tf.get_logger().setLevel(logging.WARNING)
        53     config = config_builder.build()
        54     copied_config = dict(config)
 
 AttributeError: module 'tensorflow' has no attribute 'get_logger'

