### PR TITLE
Clean up for next launch

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,8 +7,8 @@
 when testing WIT in TensorBoard)
 2. Install pip and virtualenv
    `sudo apt-get install python-pip python3-pip virtualenv`
-3. Create a virtualenv for WIT development
-   `virtualenv ~/tf` (or wherever you want to save this environment)
+3. Create a python 3 virtualenv for WIT development
+   `virtualenv -p python3 ~/tf` (or wherever you want to save this environment)
 4. Create a fork of the official What-If Tool github repo through the GitHub UI
 5. Clone your fork to your computer
    `cd ~/github && git clone https://github.com/[yourGitHubUsername]/what-if-tool.git`

--- a/tensorboard_plugin_wit/pip_package/build_pip_package.sh
+++ b/tensorboard_plugin_wit/pip_package/build_pip_package.sh
@@ -85,6 +85,5 @@ unset PYTHON_HOME
 pip install -qU wheel 'setuptools>=36.2.0'
 
 python setup.py bdist_wheel --python-tag py3 >/dev/null
-python setup.py bdist_wheel --python-tag py2 >/dev/null
 
 ls -hal "$PWD/dist"

--- a/tensorboard_plugin_wit/wit_plugin.py
+++ b/tensorboard_plugin_wit/wit_plugin.py
@@ -86,7 +86,7 @@ class WhatIfToolPlugin(base_plugin.TBPlugin):
                             context.flags.authorized_groups != '')
 
     self.custom_predict_fn = None
-    if context.flags.custom_predict_fn:
+    if context.flags and context.flags.custom_predict_fn:
       try:
         import importlib.util as iu
         spec = iu.spec_from_file_location("custom_predict_fn", context.flags.custom_predict_fn)
@@ -400,7 +400,7 @@ class WhatIfToolPlugin(base_plugin.TBPlugin):
           request.args.get('predict_output_tensor'),
           feat['observedMin'] if 'observedMin' in feat else 0,
           feat['observedMax'] if 'observedMin' in feat else 0,
-          None)
+          None, custom_predict_fn=self.custom_predict_fn)
       features_list = inference_utils.sort_eligible_features(
         features_list, chart_data)
       return http_util.Respond(request, features_list, 'application/json')

--- a/witwidget/pip_package/build_pip_package.sh
+++ b/witwidget/pip_package/build_pip_package.sh
@@ -100,8 +100,5 @@ unset PYTHON_HOME
 pip install -qU wheel 'setuptools>=36.2.0'
 
 python setup.py bdist_wheel --python-tag py3 --project_name witwidget >/dev/null
-python setup.py bdist_wheel --python-tag py2 --project_name witwidget >/dev/null
-python setup.py bdist_wheel --python-tag py3 --project_name witwidget-gpu >/dev/null
-python setup.py bdist_wheel --python-tag py2 --project_name witwidget-gpu >/dev/null
 
 ls -hal "$PWD/dist"

--- a/witwidget/pip_package/setup.py
+++ b/witwidget/pip_package/setup.py
@@ -30,7 +30,7 @@ if '--project_name' in sys.argv:
   sys.argv.pop(project_name_idx)
 
 _TF_REQ = [
-    'tensorflow>=1.12.0',
+    'tensorflow>=1.12.1',
 ]
 
 REQUIRED_PACKAGES = [

--- a/witwidget/pip_package/setup.py
+++ b/witwidget/pip_package/setup.py
@@ -33,13 +33,6 @@ _TF_REQ = [
     'tensorflow>=1.12.0',
 ]
 
-# GPU build (note: the only difference is we depend on tensorflow-gpu
-# so pip doesn't overwrite it with the CPU build)
-if 'witwidget-gpu' in project_name:
-  _TF_REQ = [
-      'tensorflow-gpu>=1.12.0',
-  ]
-
 REQUIRED_PACKAGES = [
     'absl-py >= 0.4',
     'google-api-python-client>=1.7.8',
@@ -92,8 +85,6 @@ setup(
       'Intended Audience :: Developers',
       'Intended Audience :: Science/Research',
       'Topic :: Multimedia :: Graphics',
-      'Programming Language :: Python :: 2',
-      'Programming Language :: Python :: 2.7',
       'Programming Language :: Python :: 3',
       'Programming Language :: Python :: 3.3',
       'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
Updating documentation for upcoming launch

Removing py2 and tensorflow-gpu versions of pip packages. Py2 support is gone in 2020 and tensorflow-gpu has been deprecated.

Small fixes from last PR on custom predict functions in TensorBoard.

