### PR TITLE
loader: import `argparse`

### DIFF
--- a/tensorboard_plugin_wit/wit_plugin_loader.py
+++ b/tensorboard_plugin_wit/wit_plugin_loader.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import argparse
+
 import pkg_resources
 import tensorboard
 from tensorboard.plugins import base_plugin


### PR DESCRIPTION
Summary:
When the `except argparse.ArgumentError` case is hit, the code throws
anyway because the `argparse` identifier is not bound.

Test Plan:
Running `flake8 --select=F82` to check for name binding violations now
reports the whole repository as clean; previously, it caught this error.

wchargin-branch: import-argparse
