### PR TITLE
Jupyter notebook scaling update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bazel-*
 .DS_Store
 website/www/
 website/node_modules/
+.vscode/

--- a/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/witwidget/notebook/jupyter/js/lib/wit.js
@@ -161,25 +161,28 @@ var WITView = widgets.DOMWidgetView.extend({
       return;
     }
     const i = this.model.get('examples_batch_id')
-    // If batch number is -1, it means the transfer is complete.
-    if (i == -1) {
-      console.log('called exampleschanged')
-      this.examplesChanged();
-      return;
-    }
-    // If transfer starts again, reset staged examples.
-    if (i == 0) {
-      this.stagedExamples = []
-    }
+    // // If count is -1 reset transfer. This is used in case backend ends the
+    // // transfer early (i.e. set_examples is called before examples are loaded).
+    // if (i == -1){
+    //   this.stagedExamples = []
+    //   return;
+    // }
     console.log('appendStagedExamples', i);
     // Add examples
     const examples = this.model.get('examples_batch');
-    console.log('examples', examples);
-    this.stagedExamples = this.stagedExamples.concat(examples);
+    console.log('examples', examples.length);
+    this.stagedExamples.push(...examples);
     // Request the next batch
-    this.model.set('examples_batch_id', i + 1);
+    this.model.set('examples_batch_id', i - 1);
     this.touch();
-    console.log('stagedExamples', this.stagedExamples);
+    // If batch number is 0, it means the transfer is complete.
+    if (i == 0) {
+      console.log('called exampleschanged')
+      this.examplesChanged();
+      // Reset staged examples at the end of the transfer.
+      this.stagedExamples = []
+    }
+    console.log('stagedExamples', this.stagedExamples.length);
   },
   examplesChanged: function() {
     if (!this.setupComplete) {
@@ -189,8 +192,6 @@ var WITView = widgets.DOMWidgetView.extend({
       requestAnimationFrame(() => this.examplesChanged());
       return;
     }
-    console.log('examplesChanged');
-    console.log(this.stagedExamples);
     const examples = this.stagedExamples;
     if (examples && examples.length > 0) {
       this.view_.updateExampleContents(examples, false);

--- a/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/witwidget/notebook/jupyter/js/lib/wit.js
@@ -161,28 +161,19 @@ var WITView = widgets.DOMWidgetView.extend({
       return;
     }
     const i = this.model.get('examples_batch_id')
-    // // If count is -1 reset transfer. This is used in case backend ends the
-    // // transfer early (i.e. set_examples is called before examples are loaded).
-    // if (i == -1){
-    //   this.stagedExamples = []
-    //   return;
-    // }
-    console.log('appendStagedExamples', i);
+    console.log('Remaining batches: ' + i + 'loaded: ' + this.stagedExamples.length);
     // Add examples
     const examples = this.model.get('examples_batch');
-    console.log('examples', examples.length);
     this.stagedExamples.push(...examples);
     // Request the next batch
     this.model.set('examples_batch_id', i - 1);
     this.touch();
     // If batch number is 0, it means the transfer is complete.
     if (i == 0) {
-      console.log('called exampleschanged')
       this.examplesChanged();
       // Reset staged examples at the end of the transfer.
       this.stagedExamples = []
     }
-    console.log('stagedExamples', this.stagedExamples.length);
   },
   examplesChanged: function() {
     if (!this.setupComplete) {

--- a/witwidget/notebook/jupyter/wit.py
+++ b/witwidget/notebook/jupyter/wit.py
@@ -117,8 +117,6 @@ class WitWidget(widgets.DOMWidget, base.WitWidgetBase):
     self.error_counter += 1
 
   def _start_examples_sync(self):
-    # print(self.frontend_ready)
-    # print(self.examples_generator)
     if not self.frontend_ready or self.examples_generator is None or self.transfer_block:
       return
     self.transfer_block = True
@@ -137,7 +135,6 @@ class WitWidget(widgets.DOMWidget, base.WitWidgetBase):
   @observe('frontend_ready')
   def _finish_setup(self, change):
     # Start examples transfer
-    # print('finished setup')
     self._start_examples_sync()
 
   # When frontend processes sent examples, it updates batch id to request the
@@ -145,17 +142,12 @@ class WitWidget(widgets.DOMWidget, base.WitWidgetBase):
   @observe('examples_batch_id')
   def _send_example_batch(self, change):
     # Do not trigger at the end of a transfer.
-    # print('send example batch')
     if self.examples_batch_id < 0 or self.examples_generator is None:
-      # print('returned from send example batch {} {}'.format(self.examples_batch_id, self.examples_generator is None))
       return
     self.examples_batch, num_remaining = next(self.examples_generator, ([], -1))
-    # print(len(self.examples_batch))
-    # print(num_remaining)
     if num_remaining == 0:
       self.examples_generator = None
       self.transfer_block = False
-      # print('Transfer complete.')
 
   # Observer callbacks for changes from javascript.
   @observe('get_eligible_features')


### PR DESCRIPTION
Batch examples during transfer to the frontend from the backend such that we do not exceed websocket limit (I think 10MB). Tested for up to 500k examples in jupyter notebook with current changes in chrome with census notebook.