### PR TITLE
Enable WitWidget in JupyterLab2

### DIFF
--- a/witwidget/notebook/jupyter/js/lib/index.js
+++ b/witwidget/notebook/jupyter/js/lib/index.js
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 window.__nbextension_path__ =
-  document.querySelector('body').getAttribute('data-base-url') +
+  (document.querySelector('body').getAttribute('data-base-url') || '/') +
   'nbextensions/wit-widget/';
 
 // Export widget models and views.

--- a/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/witwidget/notebook/jupyter/js/lib/wit.js
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-var witHtmlLocation = require('file-loader!./wit_jupyter.html');
 var widgets = require('@jupyter-widgets/base');
 
 // What-If Tool View. Renders the tool and provides communication with the
@@ -51,11 +50,7 @@ var WITView = widgets.DOMWidgetView.extend({
       parseInt(this.model.attributes.layout.attributes.height, 10) - 20;
     const iframe = document.createElement('iframe');
 
-    // Adjust WIT html location if running in a jupyter notebook
-    // and not in jupyterlab.
-    if (document.body.getAttribute('data-base-url') != null) {
-      witHtmlLocation = window.__nbextension_path__ + 'wit_jupyter.html';
-    }
+    const witHtmlLocation = window.__nbextension_path__ + 'wit_jupyter.html';
 
     iframe.frameBorder = '0';
     iframe.style.width = '100%';

--- a/witwidget/notebook/jupyter/js/package.json
+++ b/witwidget/notebook/jupyter/js/package.json
@@ -22,13 +22,11 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "file-loader": "^3.0.1",
     "rimraf": "^2.6.1",
     "webpack": "^3.5.5"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.1.10 || ^2",
-    "@jupyter-widgets/jupyterlab-manager": ">=0.38.1 <2.0.0"
+    "@jupyter-widgets/base": "^1.1 || ^2 || ^3"
   },
   "jupyterlab": {
     "extension": "lib/labplugin"


### PR DESCRIPTION
To fix #71

Removed unnecessary use of file-loader, which had issues with ES6 and JupyterLab 2
Simplified __nbextension_path__ setting/logic
Updated wit-widget package.json to support all JupyterLab versions and remove conflicting and unnecessary dep on jupyterlab-manager (TFMA package, which works the same way, doesn't have this dependency, for example).