### PR TITLE
Change /bin/sh to /bin/bash in build_pip_package.sh

### DIFF
--- a/tensorboard_plugin_wit/pip_package/build_pip_package.sh
+++ b/tensorboard_plugin_wit/pip_package/build_pip_package.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2018 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/witwidget/pip_package/build_pip_package.sh
+++ b/witwidget/pip_package/build_pip_package.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2018 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Related to #34, #35

It seems that `build_pip_package.sh` requires `pushd`, which is unknown in `sh` and prevented me from building. 

This commit allows me to build the package. If there is no good reason to use `/bin/sh`, I propose to explicitly require `/bin/bash`. Otherwise, I do not see a good way to build the package on a system without root access and default shell `sh`. 

Let me know what you think!