### PR TITLE
Add support for JupyterLab 3.x and bump version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,15 +391,17 @@ Then, use it as seen at the bottom of the
 [What_If_Tool_Notebook_Usage.ipynb notebook](https://colab.research.google.com/github/pair-code/what-if-tool/blob/master/What_If_Tool_Notebook_Usage.ipynb).
 
 ### How do I enable it for use in a JupyterLab or Cloud AI Platform notebook?
-WIT has been tested in JupyterLab versions 1.x and 2.x.
+WIT has been tested in JupyterLab versions 1.x, 2.x, and 3.x.
 
-Install and enable WIT for JupyterLab 2.x by running a cell containing:
+Install and enable WIT for JupyterLab 3.x by running a cell containing:
 ```
 !pip install witwidget
 !jupyter labextension install wit-widget
-!jupyter labextension install @jupyter-widgets/jupyterlab-manager@2
+!jupyter labextension install @jupyter-widgets/jupyterlab-manager
 ```
-Note that you need to specify the correct version of jupyterlab-manager for your JupyterLab version as per https://www.npmjs.com/package/@jupyter-widgets/jupyterlab-manager.
+Note that you may need to specify the correct version of jupyterlab-manager for
+you JupyterLab version as per
+https://www.npmjs.com/package/@jupyter-widgets/jupyterlab-manager.
 
 Note that you may need to run `!sudo jupyter labextension ...` commands depending on your notebook setup.
 

--- a/witwidget/notebook/jupyter/js/package.json
+++ b/witwidget/notebook/jupyter/js/package.json
@@ -3,7 +3,7 @@
   "description": "What-If Tool jupyter widget",
   "author": "Google LLC",
   "main": "dist/index.js",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license" : "Apache 2.0",
   "homepage": "https://github.com/pair-code/what-if-tool",
   "keywords": [
@@ -26,7 +26,7 @@
     "webpack": "^3.5.5"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.1 || ^2 || ^3"
+    "@jupyter-widgets/base": "^1.1 || ^2 || ^3 || ^4"
   },
   "jupyterlab": {
     "extension": "lib/labplugin"

--- a/witwidget/pip_package/setup.py
+++ b/witwidget/pip_package/setup.py
@@ -37,7 +37,6 @@ REQUIRED_PACKAGES = [
     'absl-py >= 0.4',
     'google-api-python-client>=1.7.8',
     'ipywidgets>=7.0.0',
-    'jupyter>=1.0,<2',
     'oauth2client>=4.1.3',
     'six>=1.12.0',
 ] + _TF_REQ

--- a/witwidget/version.py
+++ b/witwidget/version.py
@@ -14,4 +14,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.8.0'
+VERSION = '1.8.1'


### PR DESCRIPTION
- Add support for JupyterLab 3.x (tested locally and in Vertex AI notebooks)
- Bump version number to 1.8.1
- Remove unneeded pip package dep on jupyter as this package is only used in the context of jupyter notebooks anyways.