### PR TITLE
Fix WIT backend calls when TensorBoard uses path_prefix option

### DIFF
--- a/tensorboard_plugin_wit/pip_package/setup.py
+++ b/tensorboard_plugin_wit/pip_package/setup.py
@@ -25,7 +25,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tensorboard_plugin_wit",
-    version="1.8.0",
+    version="1.8.1",
     description="What-If Tool TensorBoard plugin.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -7850,7 +7850,7 @@ limitations under the License.
           if (!this.local) {
             let tempInferences = [];
             let tempExtraOutputs = [];
-            const url = this.makeUrl_('/data/plugin/whatif/infer', inferParams);
+            const url = this.makeUrl_('/infer', inferParams);
             const inferContents = (result) => {
               if (result.value.vocab != null) {
                 this.labelVocab = /** @type {!Array} */ (JSON.parse(
@@ -7870,7 +7870,7 @@ limitations under the License.
                   extra: extraOutputs
                 };
               } else {
-                const url = this.makeUrl_('/data/plugin/whatif/infer', {
+                const url = this.makeUrl_('/infer', {
                   start_example: result.value.next,
                   model_type: this.modelType,
                 });
@@ -8061,7 +8061,7 @@ limitations under the License.
         updateExample_: function(exampleJson, index) {
           this.fire('update-example', {example: exampleJson, index: index});
           if (!this.local) {
-            var url = this.makeUrl_('/data/plugin/whatif/update_example', null);
+            var url = this.makeUrl_('/update_example', null);
 
             this.makeAsyncRequest_(
               url,
@@ -8076,16 +8076,9 @@ limitations under the License.
           return 'inference_';
         },
 
-        makeUrl_: function(prefix, paramsDict) {
-          const url = prefix;
-          if (paramsDict) {
-            prefix +=
-              '?' +
-              Object.keys(paramsDict)
-                .map((k) => k + '=' + encodeURIComponent(paramsDict[k]))
-                .join('&');
-          }
-          return prefix;
+        makeUrl_: function(endpoint, paramsDict) {
+          return '/' + tf_backend.getRouter().pluginRoute(
+            'whatif', endpoint, new URLSearchParams(paramsDict));
         },
 
         showToast_: function(msg) {
@@ -8330,7 +8323,7 @@ limitations under the License.
         getExamples_: function() {
           let tempExamples = [];
           let tempSprite = null;
-          const url = this.makeUrl_('/data/plugin/whatif/examples_from_path', {
+          const url = this.makeUrl_('/examples_from_path', {
             examples_path: this.examplesPath,
             max_examples: this.maxExamples,
             sampling_odds: this.samplingOdds,
@@ -8348,7 +8341,7 @@ limitations under the License.
                 tempSprite
               );
             } else {
-              const url = this.makeUrl_('/data/plugin/whatif/examples_from_path', {
+              const url = this.makeUrl_('/examples_from_path', {
                 start_example: result.value.next
               });
               this.makeAsyncRequest_(
@@ -8373,10 +8366,7 @@ limitations under the License.
           if (this.hasSprite) {
             this.$.dive.atlasUrl = null;
             if (!this.local) {
-              this.$.dive.atlasUrl = this.makeUrl_(
-                '/data/plugin/whatif/sprite',
-                {}
-              );
+              this.$.dive.atlasUrl = this.makeUrl_('/sprite', {});
             } else {
               this.$.dive.atlasUrl = this.localAtlasUrl;
             }
@@ -8428,7 +8418,7 @@ limitations under the License.
             const refreshDiveAfterDuplicate = (result) => {
               this.refreshDive_();
             };
-            const url = this.makeUrl_('/data/plugin/whatif/duplicate_example', {
+            const url = this.makeUrl_('/duplicate_example', {
               index: duplicatedIndex,
             });
             this.makeAsyncRequest_(
@@ -8469,7 +8459,7 @@ limitations under the License.
             const refreshDiveAfterDelete = (result) => {
               this.refreshDive_();
             };
-            const url = this.makeUrl_('/data/plugin/whatif/delete_example', {
+            const url = this.makeUrl_('/delete_example', {
               index: deletedIndex,
             });
             this.makeAsyncRequest_(
@@ -9011,10 +9001,7 @@ limitations under the License.
 
           // Call into backend.
           if (!this.local) {
-            const url = tf_backend.addParams(
-              '/data/plugin/whatif/infer_mutants',
-              urlParams
-            );
+            const url = this.makeUrl_('/infer_mutants', urlParams);
             const chartMakerCallback = (result) => {
               return this.makeChartForFeature(
                 result.value.chartType,
@@ -9241,10 +9228,7 @@ limitations under the License.
 
           // Call into the backend to get the possible features to show plots for.
           if (!this.local) {
-            const url = tf_backend.addParams(
-              '/data/plugin/whatif/eligible_features',
-              {}
-            );
+            const url = this.makeUrl_('/eligible_features', {});
             const setEligibleFields = (result) => {
               this.set('partialDepPlotEligibleFeatures', result.value);
             };
@@ -9271,10 +9255,7 @@ limitations under the License.
           this.isSortingEligibleFeatures = true;
           // Call into the backend to sort the possible features to show plots for.
           if (!this.local) {
-            const url = tf_backend.addParams(
-              '/data/plugin/whatif/sort_eligible_features',
-              urlParams
-            );
+            const url = this.makeUrl_('/sort_eligible_features', urlParams);
             const setEligibleFields = (result) => {
               this.set('partialDepPlotEligibleFeatures', result.value);
             };

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -7850,7 +7850,7 @@ limitations under the License.
           if (!this.local) {
             let tempInferences = [];
             let tempExtraOutputs = [];
-            const url = this.makeUrl_('/infer', inferParams);
+            const url = this.makeUrl_('infer', inferParams);
             const inferContents = (result) => {
               if (result.value.vocab != null) {
                 this.labelVocab = /** @type {!Array} */ (JSON.parse(
@@ -7870,7 +7870,7 @@ limitations under the License.
                   extra: extraOutputs
                 };
               } else {
-                const url = this.makeUrl_('/infer', {
+                const url = this.makeUrl_('infer', {
                   start_example: result.value.next,
                   model_type: this.modelType,
                 });
@@ -8061,7 +8061,7 @@ limitations under the License.
         updateExample_: function(exampleJson, index) {
           this.fire('update-example', {example: exampleJson, index: index});
           if (!this.local) {
-            var url = this.makeUrl_('/update_example', null);
+            var url = this.makeUrl_('update_example', null);
 
             this.makeAsyncRequest_(
               url,
@@ -8077,8 +8077,15 @@ limitations under the License.
         },
 
         makeUrl_: function(endpoint, paramsDict) {
-          return '/' + tf_backend.getRouter().pluginRoute(
-            'whatif', endpoint, new URLSearchParams(paramsDict));
+          // Strip off any leading slash to ensure relative path.
+          if (endpoint[0] === '/') {
+            endpoint = endpoint.slice(1)
+          }
+          const url = tf_backend.addParams(
+              endpoint,
+              paramsDict
+            );
+          return url;
         },
 
         showToast_: function(msg) {
@@ -8323,7 +8330,7 @@ limitations under the License.
         getExamples_: function() {
           let tempExamples = [];
           let tempSprite = null;
-          const url = this.makeUrl_('/examples_from_path', {
+          const url = this.makeUrl_('examples_from_path', {
             examples_path: this.examplesPath,
             max_examples: this.maxExamples,
             sampling_odds: this.samplingOdds,
@@ -8341,7 +8348,7 @@ limitations under the License.
                 tempSprite
               );
             } else {
-              const url = this.makeUrl_('/examples_from_path', {
+              const url = this.makeUrl_('examples_from_path', {
                 start_example: result.value.next
               });
               this.makeAsyncRequest_(
@@ -8366,7 +8373,7 @@ limitations under the License.
           if (this.hasSprite) {
             this.$.dive.atlasUrl = null;
             if (!this.local) {
-              this.$.dive.atlasUrl = this.makeUrl_('/sprite', {});
+              this.$.dive.atlasUrl = this.makeUrl_('sprite', {});
             } else {
               this.$.dive.atlasUrl = this.localAtlasUrl;
             }
@@ -8418,7 +8425,7 @@ limitations under the License.
             const refreshDiveAfterDuplicate = (result) => {
               this.refreshDive_();
             };
-            const url = this.makeUrl_('/duplicate_example', {
+            const url = this.makeUrl_('duplicate_example', {
               index: duplicatedIndex,
             });
             this.makeAsyncRequest_(
@@ -8459,7 +8466,7 @@ limitations under the License.
             const refreshDiveAfterDelete = (result) => {
               this.refreshDive_();
             };
-            const url = this.makeUrl_('/delete_example', {
+            const url = this.makeUrl_('delete_example', {
               index: deletedIndex,
             });
             this.makeAsyncRequest_(
@@ -9001,7 +9008,7 @@ limitations under the License.
 
           // Call into backend.
           if (!this.local) {
-            const url = this.makeUrl_('/infer_mutants', urlParams);
+            const url = this.makeUrl_('infer_mutants', urlParams);
             const chartMakerCallback = (result) => {
               return this.makeChartForFeature(
                 result.value.chartType,
@@ -9228,7 +9235,7 @@ limitations under the License.
 
           // Call into the backend to get the possible features to show plots for.
           if (!this.local) {
-            const url = this.makeUrl_('/eligible_features', {});
+            const url = this.makeUrl_('eligible_features', {});
             const setEligibleFields = (result) => {
               this.set('partialDepPlotEligibleFeatures', result.value);
             };
@@ -9255,7 +9262,7 @@ limitations under the License.
           this.isSortingEligibleFeatures = true;
           // Call into the backend to sort the possible features to show plots for.
           if (!this.local) {
-            const url = this.makeUrl_('/sort_eligible_features', urlParams);
+            const url = this.makeUrl_('sort_eligible_features', urlParams);
             const setEligibleFields = (result) => {
               this.set('partialDepPlotEligibleFeatures', result.value);
             };

--- a/wit_dashboard/wit-dashboard.html
+++ b/wit_dashboard/wit-dashboard.html
@@ -8081,6 +8081,9 @@ limitations under the License.
           if (endpoint[0] === '/') {
             endpoint = endpoint.slice(1)
           }
+          if (paramsDict == null) {
+            paramsDict = {};
+          }
           const url = tf_backend.addParams(
               endpoint,
               paramsDict


### PR DESCRIPTION
TensorBoard can be launched with a `--path_prefix=[path]` option to set a path prefix in the URL of tensorboard (useful when running in certain environments such as notebooks). WIT was using a hard-coded absolute path for its calls to the TensorBoard WIT backend, which would fail when TB was launched with a path_prefix.

This fix updates the WIT backend calls (these are only done when WIT is being used inside TensorBoard) to be relative paths, so the path_prefix is correctly used by the TensorBoard request manager. This fix also uses TB's addParams method universally instead of adding query params by hand.

Tested this fix both with a standard TB instance and one with a path_prefix set and ensured that WIT works correctly in both situations now.

Fixes #190 and https://github.com/tensorflow/tensorboard/issues/5472