### PR TITLE
Update WIT_Toxicity_Text_Model_Comparison.ipynb

### DIFF
--- a/WIT_Toxicity_Text_Model_Comparison.ipynb
+++ b/WIT_Toxicity_Text_Model_Comparison.ipynb
@@ -337,7 +337,7 @@
       },
       "source": [
         "#@title Add a feature column for each identity term to indicate if it exists in the comment\n",
-        "!wget https://raw.githubusercontent.com/conversationai/unintended-ml-bias-analysis/master/unintended_ml_bias/bias_madlibs_data/adjectives_people.txt\n",
+        "!wget https://raw.githubusercontent.com/conversationai/unintended-ml-bias-analysis/main/archive/unintended_ml_bias/bias_madlibs_data/adjectives_people.txt\n",
         "\n",
         "import re\n",
         "import six\n",


### PR DESCRIPTION
Link to adjectives_people.txt file from unintended bias github was broken. Updated with new link from their latest repo structure.